### PR TITLE
chore(docs): Remove duplicate headings, add 'before you start' section

### DIFF
--- a/pull-requests.md
+++ b/pull-requests.md
@@ -21,8 +21,8 @@ The content changes go through the following stages before they are published on
 Before you start work on MDN, please go through the recommendations and guidelines listed below.
 
 **Pull requests must resolve or partially fix an existing issue.**
-  The reason why we have this restriction is to avoid that you start on any kind of task that someone else might already be working on.
-  Search issues and pull requests in the [MDN repository](https://github.com/orgs/mdn/repositories) you want to contribute to and confirm that the work you want to do is not already being done.
+The reason why we have this restriction is to avoid that you start on any kind of task that someone else might already be working on.
+Search through issues and pull requests in the [MDN repository](https://github.com/orgs/mdn/repositories) you want to contribute to and confirm that the work you want to start is not already being worked on.
 When looking to contribute to the MDN project, you will find yourself in one of the following situations:
 
 - **If you are looking to contribute to the project**, you can find tasks under 'Issues' in any of the [MDN GitHub repositories](https://github.com/orgs/mdn/repositories) (for example, [`mdn/content` issues](https://github.com/mdn/content/issues)) and our [public GitHub project boards](https://github.com/orgs/mdn/projects).
@@ -30,7 +30,7 @@ When looking to contribute to the MDN project, you will find yourself in one of 
   Issues labelled with `good first issue` are a good place to start.
 
 - **If you have found a problem on MDN**, you should open an issue first.
-  **Issues need to be triaged before you start working** so that you know a problem addressed by a pull request is valid and that your pull request will be accepted.
+  **Issues need a response from maintainers before you start working** so that you know a problem addressed by a pull request is valid and that your pull request will be accepted.
   More information on issues can be found on our [Community pages for GitHub issues](https://github.com/mdn/mdn/issues/new?assignees=schalkneethling&labels=proposal%2Cneeds+triage&template=content-or-feature-suggestion.yml&title=Enter+your+proposal+here).
 
 - **If want to suggest new content or a new feature**, submit a proposal through the 'New content or feature suggestion' [GitHub issue template](https://github.com/mdn/mdn/issues/new/choose).
@@ -50,17 +50,17 @@ If anyone has engaged in behavior that is potentially illegal or makes you or so
 
 When you're ready to open a pull request, follow these guidelines:
 
-- **Add the link to the issue you are closing:** In the pull request description, add 'Fixes' if it fully resolves the issue or 'Relates to' if it is a related issue.
-  More information about linking to issues in pull requests can be found in [GitHub docs](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
-- **Add a description of the changes:** Provide as much context and rationale for the pull request as possible.
 - **Pull requests should be short and focused to one issue:** If possible, group related set of changes into multiple, small pull requests.
   If a pull request becomes too large, the reviewer may close it and ask that you to submit pull requests for each logical set of changes that belong together.
-- **Don't make grammar-only changes:**
-  MDN Web Docs contains technical documentation; you should not suggest prose style changes except where grammar is incorrect.
+- **Add a description of the changes:** Provide as much context and rationale for the pull request as possible.
+- **Add the link to the issue you are closing:** In the pull request description, add 'Fixes' if it fully resolves the issue or 'Relates to' if it is a related issue.
+  More information about linking to issues in pull requests can be found in [GitHub docs](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
+- **Add 'depends on'** with a link to a dependency if there are pull requests that must be merged first (e.g., code examples in other repositories).
 - **Accompany code example changes with content changes:** This is important to ensure that updated examples are served correctly.
   If you're making content changes that affect how examples are used, the related code examples should also be updated.
-- **Add 'depends on'** with a link to a dependency if there are pull requests that must land first (e.g., code examples in other repositories).
 - **Add a reviewer:** You can add a reviewer, such as a team member or a topic owner, if you already know who should review your pull request.
+- **Don't make grammar-only changes:**
+  MDN Web Docs contains technical documentation; you should not suggest prose style changes except where grammar is incorrect.
 - **Don't enable auto-merge.**
 
 ### After you open a pull request

--- a/pull-requests.md
+++ b/pull-requests.md
@@ -18,9 +18,12 @@ The content changes go through the following stages before they are published on
 
 ## Before you start
 
-- **Pull requests must resolve or partially fix an existing issue.**
+Before you start work on MDN, please go through the recommendations and guidelines listed below.
+
+**Pull requests must resolve or partially fix an existing issue.**
   The reason why we have this restriction is to avoid that you start on any kind of task that someone else might already be working on.
   Search issues and pull requests in the [MDN repository](https://github.com/orgs/mdn/repositories) you want to contribute to and confirm that the work you want to do is not already being done.
+When looking to contribute to the MDN project, you will find yourself in one of the following situations:
 
 - **If you are looking to contribute to the project**, you can find tasks under 'Issues' in any of the [MDN GitHub repositories](https://github.com/orgs/mdn/repositories) (for example, [`mdn/content` issues](https://github.com/mdn/content/issues)) and our [public GitHub project boards](https://github.com/orgs/mdn/projects).
   Make sure the issue isn't assigned to someone and no one has already opened a pull request for the task.
@@ -30,7 +33,7 @@ The content changes go through the following stages before they are published on
   **Issues need to be triaged before you start working** so that you know a problem addressed by a pull request is valid and that your pull request will be accepted.
   More information on issues can be found on our [Community pages for GitHub issues](https://github.com/mdn/mdn/issues/new?assignees=schalkneethling&labels=proposal%2Cneeds+triage&template=content-or-feature-suggestion.yml&title=Enter+your+proposal+here).
 
-- **If want to suggest new content** or a new feature, please submit a proposal through the 'New content or feature suggestion' [GitHub issue template](https://github.com/mdn/mdn/issues/new/choose).
+- **If want to suggest new content or a new feature**, submit a proposal through the 'New content or feature suggestion' [GitHub issue template](https://github.com/mdn/mdn/issues/new/choose).
 
 <!-- TODO: when we have the Discord set up.
 If you're not sure where to start, reach out to us on [Discord]() and ask for feedback.
@@ -50,14 +53,14 @@ When you're ready to open a pull request, follow these guidelines:
 - **Add the link to the issue you are closing:** In the pull request description, add 'Fixes' if it fully resolves the issue or 'Relates to' if it is a related issue.
   More information about linking to issues in pull requests can be found in [GitHub docs](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
 - **Add a description of the changes:** Provide as much context and rationale for the pull request as possible.
-- **PRs should be short and focused to one issue:** If possible, group related set of changes into multiple, small PRs.
-  If a PR becomes too large, the reviewer may close it and ask that you to submit pull requests for each logical set of changes that belong together.
+- **Pull requests should be short and focused to one issue:** If possible, group related set of changes into multiple, small pull requests.
+  If a pull request becomes too large, the reviewer may close it and ask that you to submit pull requests for each logical set of changes that belong together.
 - **Don't make grammar-only changes:**
   MDN Web Docs contains technical documentation; you should not suggest prose style changes except where grammar is incorrect.
 - **Accompany code example changes with content changes:** This is important to ensure that updated examples are served correctly.
   If you're making content changes that affect how examples are used, the related code examples should also be updated.
-- **Add 'depends on'** with a link to a dependency if there are PRs that must land first (e.g., code examples in other repositories).
-- **Add a reviewer:** You can add a reviewer, such as a team member or a topic owner, if you already know who should review your PR.
+- **Add 'depends on'** with a link to a dependency if there are pull requests that must land first (e.g., code examples in other repositories).
+- **Add a reviewer:** You can add a reviewer, such as a team member or a topic owner, if you already know who should review your pull request.
 - **Don't enable auto-merge.**
 
 ### After you open a pull request
@@ -82,7 +85,7 @@ We add reviewers automatically based on a `CODEOWNERS` file but, if there is a s
 We also use auto-labeling on pull requests to help triage.
 Maintainers will triage pull requests and add any additional labels, such as `needs-info` or `on-hold`, if needed based on context.
 
-If you want to review a PR but are not listed as a reviewer, you may add yourself as one.
+If you want to review a pull request but are not listed as a reviewer, you may add yourself as one.
 It's polite to check with existing reviewers first by commenting on the pull request that you intend to start a review.
 
 ### Reviewers and assignees
@@ -96,9 +99,9 @@ The MDN Web Docs team uses reviewers and assignees to track the status of pull r
 
 A pull request reviewer or assignee is responsible for merging the changes.
 
-### If you are asked to review a PR
+### If you are asked to review a pull request
 
-Before you start with a review, check the PR description to make sure no one specific should review it.
+Before you start with a review, check the pull request description to make sure no one specific should review it.
 Ensure that all continuous integration (CI) tasks have been completed successfully and that there are no merge conflicts.
 
 If any tasks fail or there are merge conflicts, communicate this to the author; it is their responsibility to address these.
@@ -163,12 +166,12 @@ Reviewers are encouraged to read the following articles for help with common rev
 
 ## Timelines
 
-This section provides details for expected turnaround times while reviewing PRs if you're a reviewer and while responding to review comments if you're a PR author.
+This section provides details for expected turnaround times while reviewing pull requests if you're a reviewer and while responding to review comments if you're a pull request author.
 
 - **Reviews**:
-  The pull request reviewer should be able to review the PR in 2 weeks or less.
-  In the 2 weeks after the PR is open, the reviewer can:
-  - Leave a comment about when they can start reviewing the PR
+  The pull request reviewer should be able to review the changes in 2 weeks or less.
+  In the 2 weeks after a pull request is open, the reviewer can:
+  - Leave a comment about when they can start reviewing the pull request
   - Ask for technical or resource help
 - **Addressing requested changes:**
   The PR author should be able to respond to or fix the comments in 4 weeks or less.

--- a/pull-requests.md
+++ b/pull-requests.md
@@ -90,9 +90,9 @@ The MDN Web Docs team uses reviewers and assignees to track the status of pull r
 - **Reviewers** are people that assess the changes in pull request and provide feedback for the author.
 - **Assignees** are people responsible for making sure the pull request is not blocked.
   Not all pull requests have assignees, but if they do, they are responsible for making sure the pull request progresses.
-  An assignee helps the work reach a conclusion either by merging, closing or undertaking unblocking work themselves.
+  An assignee helps the work reach a conclusion either by merging, closing, or undertaking unblocking work themselves.
 
-When it comes to merging changes, the pull request reviewer or an assignee merges the PR.
+A pull request reviewer or assignee is responsible for merging the changes.
 
 ### If you are asked to review a PR
 

--- a/pull-requests.md
+++ b/pull-requests.md
@@ -19,7 +19,9 @@ The content changes go through the following stages before they are published on
 ## Before you start
 
 Make sure that you're not making changes that someone else is already working on.
-You can find tasks under 'Issues' in any of the [MDN repositories](https://github.com/orgs/mdn/repositories) (for example, [`mdn/content` issues](https://github.com/mdn/content/issues)) and our [public GitHub project boards](https://github.com/orgs/mdn/projects).
+In the [MDN repository](https://github.com/orgs/mdn/repositories) you want to work, check out the 'Issues' and 'Pull requests' tabs to confirm that an issue or pull request does not already exist related to the work you want to do.
+
+If you are looking to contribute to the project, you can find tasks under 'Issues' in any of the [ (for example, [`mdn/content` issues](https://github.com/mdn/content/issues)) and our [public GitHub project boards](https://github.com/orgs/mdn/projects).
 Make sure the issue isn't assigned to someone and no one has already opened a pull request for the task.
 
 If you have found a problem on MDN, open an issue first.

--- a/pull-requests.md
+++ b/pull-requests.md
@@ -50,7 +50,7 @@ When you're ready to open a pull request, follow these guidelines:
 - **Add a description of the changes:** Provide as much context and rationale for the pull request as possible.
 - **PRs should be short and focused to one issue:** If possible, group related set of changes into multiple, small PRs.
   If a PR becomes too large, the reviewer may close it and ask that you to submit pull requests for each logical set of changes that belong together.
-- **Don't make grammar-only changes.**
+- **Don't make grammar-only changes:**
   MDN Web Docs contains technical documentation; you should not suggest prose style changes except where grammar is incorrect.
 - **Accompany code example changes with content changes:** This is important to ensure that updated examples are served correctly.
   If you're making content changes that affect how examples are used, the related code examples should also be updated.

--- a/pull-requests.md
+++ b/pull-requests.md
@@ -18,17 +18,19 @@ The content changes go through the following stages before they are published on
 
 ## Before you start
 
-Make sure that you're not making changes that someone else is already working on.
-In the [MDN repository](https://github.com/orgs/mdn/repositories) you want to work, check out the 'Issues' and 'Pull requests' tabs to confirm that an issue or pull request does not already exist related to the work you want to do.
+- **Pull requests must resolve or partially fix an existing issue.**
+  The reason why we have this restriction is to avoid that you start on any kind of task that someone else might already be working on.
+  Search issues and pull requests in the [MDN repository](https://github.com/orgs/mdn/repositories) you want to contribute to and confirm that the work you want to do is not already being done.
 
-If you are looking to contribute to the project, you can find tasks under 'Issues' in any of the [ (for example, [`mdn/content` issues](https://github.com/mdn/content/issues)) and our [public GitHub project boards](https://github.com/orgs/mdn/projects).
-Make sure the issue isn't assigned to someone and no one has already opened a pull request for the task.
+- **If you are looking to contribute to the project**, you can find tasks under 'Issues' in any of the [ (for example, [`mdn/content` issues](https://github.com/mdn/content/issues)) and our [public GitHub project boards](https://github.com/orgs/mdn/projects).
+  Make sure the issue isn't assigned to someone and no one has already opened a pull request for the task.
+  Issues labelled with `good first issue` are a good place to start.
 
-If you have found a problem on MDN, open an issue first.
-**Issues need to be triaged before you start working** so that you know a problem addressed by a pull request is valid and that your pull request will be accepted.
-More information on issues can be found on our [Community pages for GitHub issues](https://developer.mozilla.org/en-US/docs/MDN/Community/Issues).
+- **If you have found a problem on MDN**, you should open an issue first.
+  **Issues need to be triaged before you start working** so that you know a problem addressed by a pull request is valid and that your pull request will be accepted.
+  More information on issues can be found on our [Community pages for GitHub issues](https://github.com/mdn/mdn/issues/new?assignees=schalkneethling&labels=proposal%2Cneeds+triage&template=content-or-feature-suggestion.yml&title=Enter+your+proposal+here).
 
-If want to suggest a new feature or a new set of work, please submit a proposal through the 'New content or feature suggestion' [GitHub issue template](https://github.com/mdn/mdn/issues/new/choose).
+- **If want to suggest new content** or a new feature, please submit a proposal through the 'New content or feature suggestion' [GitHub issue template](https://github.com/mdn/mdn/issues/new/choose).
 
 <!-- TODO: when we have the Discord set up.
 If you're not sure where to start, reach out to us on [Discord]() and ask for feedback.
@@ -45,7 +47,7 @@ If anyone has engaged in behavior that is potentially illegal or makes you or so
 
 When you're ready to open a pull request, follow these guidelines:
 
-- **Add the link to the issue you are closing:** Add 'Fixes' or 'Relates to' and the related issue in the description of the pull request.
+- **Add the link to the issue you are closing:** In the pull request description, add 'Fixes' if it fully resolves the issue or 'Relates to' if it is a related issue.
   More information about linking to issues in pull requests can be found in [GitHub docs](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
 - **Add a description of the changes:** Provide as much context and rationale for the pull request as possible.
 - **PRs should be short and focused to one issue:** If possible, group related set of changes into multiple, small PRs.
@@ -55,7 +57,7 @@ When you're ready to open a pull request, follow these guidelines:
 - **Accompany code example changes with content changes:** This is important to ensure that updated examples are served correctly.
   If you're making content changes that affect how examples are used, the related code examples should also be updated.
 - **Add 'depends on'** with a link to a dependency if there are PRs that must land first (e.g., code examples in other repositories).
-- **Add a reviewer** if you know who should review your PR already, such as a team member or a topic owner.
+- **Add a reviewer:** You can add a reviewer, such as a team member or a topic owner, if you already know who should review your PR.
 - **Don't enable auto-merge.**
 
 ### After you open a pull request

--- a/pull-requests.md
+++ b/pull-requests.md
@@ -46,7 +46,7 @@ If anyone has engaged in behavior that is potentially illegal or makes you or so
 When you're ready to open a pull request, follow these guidelines:
 
 - **Add the link to the issue you are closing:** Add 'Fixes' or 'Relates to' and the related issue in the description of the pull request.
-  More information about issues can be found [in our Community guidelines pages](https://developer.mozilla.org/en-US/docs/MDN/Community/Issues).
+  More information about linking to issues in pull requests can be found in [GitHub docs](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
 - **Add a description of the changes:** Provide as much context and rationale for the pull request as possible.
 - **PRs should be short and focused to one issue:** If possible, group related set of changes into multiple, small PRs.
   If a PR becomes too large, the reviewer may close it and ask that you to submit pull requests for each logical set of changes that belong together.

--- a/pull-requests.md
+++ b/pull-requests.md
@@ -1,12 +1,6 @@
 # Pull request submission and review guidelines
 
 This document describes how contributors make changes to MDN Web Docs and how the changes are reviewed and land on the site.
-
-We strongly recommend opening pull requests that close existing issues or that are part of a bigger project. You can find tasks to help with under 'Issues' in any of the [MDN repositories](https://github.com/orgs/mdn/repositories) (for example, [Issues](https://github.com/mdn/content/issues) in `mdn/content` repository) and our public [project boards](https://github.com/orgs/mdn/projects).
-
-Before embarking on any work in any of the MDN repositories, please make sure that you're not making changes that are already being made. You can do this by searching through the open 'Issues' and open 'Pull requests' in the repository you're interested in making changes.
-
-If you are looking to suggest a new feature or a new set of work, please submit a proposal through the [suggestion form]().
 Content changes to MDN Web Docs include:
 
 - **Day-to-day improvements:** for the documentation of APIs, CSS properties, platform updates and content additions.
@@ -22,6 +16,22 @@ The content changes go through the following stages before they are published on
 2. **Review:** Your changes are reviewed by [MDN members and volunteers](#pull-request-review-process).
 3. **Publishing:** Updated content goes live within a day of merging via a site rebuild once every 24 hours.
 
+## Before you start
+
+Make sure that you're not making changes that someone else is already working on.
+You can find tasks under 'Issues' in any of the [MDN repositories](https://github.com/orgs/mdn/repositories) (for example, [`mdn/content` issues](https://github.com/mdn/content/issues)) and our [public GitHub project boards](https://github.com/orgs/mdn/projects).
+Make sure the issue isn't assigned to someone and no one has already opened a pull request for the task.
+
+If you have found a problem on MDN, open an issue first.
+**Issues need to be triaged before you start working** so that you know a problem addressed by a pull request is valid and that your pull request will be accepted.
+More information on issues can be found on our [Community pages for GitHub issues](https://developer.mozilla.org/en-US/docs/MDN/Community/Issues).
+
+If want to suggest a new feature or a new set of work, please submit a proposal through the 'New content or feature suggestion' [GitHub issue template](https://github.com/mdn/mdn/issues/new/choose).
+
+<!-- TODO: when we have the Discord set up.
+If you're not sure where to start, reach out to us on [Discord]() and ask for feedback.
+-->
+
 ## Values and participation
 
 We want MDN Web Docs to be a welcoming, friendly community that we can all be proud of.
@@ -31,26 +41,19 @@ If anyone has engaged in behavior that is potentially illegal or makes you or so
 
 ## Opening a pull request
 
-### If you find something you want to work on
-
-Ideally you'll have found an issue or project task to work on before opening a pull request. Every pull request opened should be to close an existing issue. If you haven't check through issues on repos or public project boards to find something. If you have found a problem on MDN open an issue - more [information on issues can be found here](). **Issues need to be triaged before work can start.**
-
-Make sure the issue isn't assigned and no one has already opened a pull request for the task. You can do that by checking the issue and searching open pull requests
-
-If you're not sure where to start, reach out to us on [Discord]() and ask for feedback before starting on any work.
-
-### Opening a pull request
-
 When you're ready to open a pull request, follow these guidelines:
 
-- **PRs should be short and focused to one issue:** If possible, group related set of changes into multiple, small PRs. If a PR becomes too large, the reviewer may close it and ask that you to submit pull requests for each logical set of changes that belong together.
-- **Add a description of what the pull request is doing:** Provide as much context and reason for opening the pull request.
-- **Add the link to the issue you are closing or working on:** Add 'Fixes' or 'Relates to' and the related issue in the description of the pull request. See [github link here]()
-- **Accompany code example changes with content changes:** This is important to ensure that updated examples are served correctly. If content changes also affect how examples are used, the related code examples should be updated in associated repositories.
-- **Add 'depends on'** with a link to a dependency if there are PRs that must land first (e.g. linked examples in other repos).
-- **Add a reviewer** if you know who should review your PR already, such as a team member or a topic owner.
+- **Add the link to the issue you are closing:** Add 'Fixes' or 'Relates to' and the related issue in the description of the pull request.
+  More information about issues can be found [in our Community guidelines pages](https://developer.mozilla.org/en-US/docs/MDN/Community/Issues).
+- **Add a description of the changes:** Provide as much context and rationale for the pull request as possible.
+- **PRs should be short and focused to one issue:** If possible, group related set of changes into multiple, small PRs.
+  If a PR becomes too large, the reviewer may close it and ask that you to submit pull requests for each logical set of changes that belong together.
 - **Don't make grammar-only changes.**
   MDN Web Docs contains technical documentation; you should not suggest prose style changes except where grammar is incorrect.
+- **Accompany code example changes with content changes:** This is important to ensure that updated examples are served correctly.
+  If you're making content changes that affect how examples are used, the related code examples should also be updated.
+- **Add 'depends on'** with a link to a dependency if there are PRs that must land first (e.g., code examples in other repositories).
+- **Add a reviewer** if you know who should review your PR already, such as a team member or a topic owner.
 - **Don't enable auto-merge.**
 
 ### After you open a pull request
@@ -78,11 +81,18 @@ Maintainers will triage pull requests and add any additional labels, such as `ne
 If you want to review a PR but are not listed as a reviewer, you may add yourself as one.
 It's polite to check with existing reviewers first by commenting on the pull request that you intend to start a review.
 
-When it comes to merging, the PR reviewer or an **assignee** merges the PR.
+### Reviewers and assignees
 
-A note about reviewers and assignees. Reviewers are those that review the pull request and give feedback. Assignees are those that are assigned to do work on the pull request, either to reach a conclusion (either by merging or closing) or to undertake further work.
+The MDN Web Docs team uses reviewers and assignees to track the status of pull requests.
 
-### If you are assigned to review a PR
+- **Reviewers** are people that assess the changes in pull request and provide feedback for the author.
+- **Assignees** are people responsible for making sure the pull request is not blocked.
+  Not all pull requests have assignees, but if they do, they are responsible for making sure the pull request progresses.
+  An assignee helps the work reach a conclusion either by merging, closing or undertaking unblocking work themselves.
+
+When it comes to merging changes, the pull request reviewer or an assignee merges the PR.
+
+### If you are asked to review a PR
 
 Before you start with a review, check the PR description to make sure no one specific should review it.
 Ensure that all continuous integration (CI) tasks have been completed successfully and that there are no merge conflicts.
@@ -152,8 +162,8 @@ Reviewers are encouraged to read the following articles for help with common rev
 This section provides details for expected turnaround times while reviewing PRs if you're a reviewer and while responding to review comments if you're a PR author.
 
 - **Reviews**:
-  The assigned reviewer should be able to review the PR in 2 weeks or less.
-  In the 2 weeks after the PR is open, the assigned reviewer can:
+  The pull request reviewer should be able to review the PR in 2 weeks or less.
+  In the 2 weeks after the PR is open, the reviewer can:
   - Leave a comment about when they can start reviewing the PR
   - Ask for technical or resource help
 - **Addressing requested changes:**

--- a/pull-requests.md
+++ b/pull-requests.md
@@ -22,7 +22,7 @@ The content changes go through the following stages before they are published on
   The reason why we have this restriction is to avoid that you start on any kind of task that someone else might already be working on.
   Search issues and pull requests in the [MDN repository](https://github.com/orgs/mdn/repositories) you want to contribute to and confirm that the work you want to do is not already being done.
 
-- **If you are looking to contribute to the project**, you can find tasks under 'Issues' in any of the [ (for example, [`mdn/content` issues](https://github.com/mdn/content/issues)) and our [public GitHub project boards](https://github.com/orgs/mdn/projects).
+- **If you are looking to contribute to the project**, you can find tasks under 'Issues' in any of the [MDN GitHub repositories](https://github.com/orgs/mdn/repositories) (for example, [`mdn/content` issues](https://github.com/mdn/content/issues)) and our [public GitHub project boards](https://github.com/orgs/mdn/projects).
   Make sure the issue isn't assigned to someone and no one has already opened a pull request for the task.
   Issues labelled with `good first issue` are a good place to start.
 


### PR DESCRIPTION
__Additions:__
* 'Before you start' section
* 'Reviewers and assignees' section
 
__Changes:__
* Remove duplicate `Opening a pull request` headings
* Reword "assigned as a reviewer" and other 'assigned' references in the context of pull requests

