### PR TITLE
Issue guidelines review

### DIFF
--- a/issues.md
+++ b/issues.md
@@ -144,7 +144,7 @@ The overall process for triaging includes some [general](#general_triaging_tasks
 - Apart from triaging incoming issues every week, review the list of old bugs to see if there are any that are stalled, need closing, or are no longer relevant.
   - Check assigned issues that are still open to see if the assignee is making progress. If there is no progress after a week of being assigned, ask them if they still have time to work on the issue. If another week passes by without any progress, unassign them and leave a comment indicating that you're making the issue available for other interested contributors.
   - If a pull request has been opened to fix the issue but has not been reviewed for a week, give the reviewer a gentle ping to ask if they can get to it.
-  - If a pull request to fix the issue is waiting on review comments to be addressed after a week, then ask the submitter if they can respond to their review. If another week goes by, either fix the review comments yourself if you have time, or close the pull request and unassign the related issue.
+  - If a pull request to fix the issue is waiting on review comments to be addressed after a week, then ask the author if they can respond to their review. If another week goes by, either fix the review comments yourself if you have time, or close the pull request and unassign the related issue.
 
 ### Issue-specific triaging tasks
 
@@ -159,7 +159,7 @@ Review each issue against the following checklist to ensure that the issue conta
 - URL of an example page or repository related to the bug, if appropriate.
 - A clear description of what the problem is.
 
-If any of the above information is not present, then you should ask the submitter of the issue to provide these details and resume triaging the issue only after those details have been provided.
+If any of the above information is not present, then you should ask the author of the issue to provide these details and resume triaging the issue only after those details have been provided.
 
 #### Set a priority label
 

--- a/issues.md
+++ b/issues.md
@@ -114,7 +114,8 @@ These are the general steps for working on an issue:
 
 If you spot a bug — whether it's a problem with the website's look and feel or an error in documentation — you can try to fix it yourself. Learn how you can contribute by going through our [contribution guide](https://github.com/mdn/content/blob/main/CONTRIBUTING.md).
 
-In general, begin by [opening the issue](#guidelines_for_reporting_an_issue). Add a comment about your intent to work on the issue.
+In general, begin by [opening the issue](#guidelines_for_reporting_an_issue). Add a comment about your intent to work on the issue and if possible, your proposed solution or steps to fix the issue.
+Wait for the issue to be triaged, for the MDN Web Docs team to verify that the issue is legit and to approve your proposed solution. (If you open a pull request before the issue has been triaged, your time and effort might go waste if the linked issue is deemed invalid or the solution is not inline with the one expected by the MDN Web Docs team.)
 After the issue is triaged, assign the issue to yourself.
 Using the [guidelines on working on an issue](#Guidelines_for_working_on_an_issue), try to fix the problem by updating the appropriate source, such as:
 

--- a/issues.md
+++ b/issues.md
@@ -21,7 +21,7 @@ While reporting an issue or participating in a conversation in an issue, always 
 Do the following:
 
 - Before filing an issue, consider if you need to start a [discussion](https://github.com/mdn/mdn-community/discussions) in the MDN Web Docs project on GitHub. Use discussions to gain different viewpoints and to converge on an agreed upon course of action. This helps to keep issues focused and productive.
-- Before filing an issue, read our [contribution guide](https://github.com/mdn/content/blob/main/CONTRIBUTING.md) to try to fix the problem yourself.
+- After filing an issue, try to fix the problem yourself. Read our [contribution guide](https://github.com/mdn/content/blob/main/CONTRIBUTING.md) to learn more.
 - If you have a question, you can ask using mechanisms like [chat rooms](https://chat.mozilla.org/#/room/#mdn:mozilla.org) or [forums](https://discourse.mozilla.org/c/mdn/236) without filing an issue.
 
 Avoid doing the following:
@@ -40,7 +40,7 @@ If you think you've found a bug with the content on MDN Web Docs or with the loo
 
 ### Reporting an issue
 
-- Depending on the problem you've discovered, report it by filing a [documentation issue](https://github.com/mdn/content/issues), a [localization issue](https://github.com/mdn/translated-content/issues), or a [platform issue](https://github.com/mdn/yari/issues).
+- Depending on the problem you've discovered, report it by filing a [documentation issue](https://github.com/mdn/content/issues), a [translation issue](https://github.com/mdn/translated-content/issues), or a [website look and feel issue](https://github.com/mdn/yari/issues).
 
 - To open an issue, use the appropriate template available in the repository. For example, to report a content bug, use the the [Content issue](<https://github.com/mdn/content/issues/new?assignees=&labels=needs+triage&template=content-bug.yml>) template in the `mdn/content` repository.
 
@@ -92,11 +92,11 @@ Remember that if you take on an issue, the expectation is for the work to be com
 
 These are the general steps for working on an issue:
 
-1. **Find an issue:** If you're looking to contribute, search for issues with `help wanted` or `good first issue` label. Most repositories have issues with these labels. You are welcome to browse and pick an issue that is suitable for your skill set.
+1. **Find an issue:** If you're looking to contribute, search for issues with `help wanted` or `good first issue` label. Most repositories have issues with these labels. You are welcome to browse and pick an issue that is suitable for your skill set. Another useful place to look for issues to work on is the [MDN Contributors Task Board](https://github.com/orgs/mdn/projects/25). This project view lists open issues from multiple repositories. You can filter the list based on the topics (`Labels` column) you're interested in. See the description of some of the [labels](#Set_other_labels) that get applied during the issue triage process.
 
    > **Note:** An issue with the `needs triage` label indicates that the MDN Web Docs core team has not reviewed the issue yet, and you shouldn't begin work on it.
 
-2. **Assign yourself to the issue:** After finding an issue you'd like to work on, make sure no one else is assigned to the issue. Add a comment saying you would like to work on it, and assign the issue to yourself.
+2. **Assign the issue to yourself:** After finding an issue you'd like to work on, make sure no one else is assigned to the issue. Add a comment saying you would like to work on it, and [assign the issue to yourself](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users#assigning-an-individual-issue-or-pull-request).
 
 3. **Do the research:** Most issues need some investigation before work can start.
 
@@ -116,7 +116,7 @@ These are the general steps for working on an issue:
 If you spot a bug — whether it's a problem with the website's look and feel or an error in documentation — you can try to fix it yourself. Learn how you can contribute by going through our [contribution guide](https://github.com/mdn/content/blob/main/CONTRIBUTING.md).
 
 In general, begin by [opening the issue](#guidelines_for_reporting_an_issue). Add a comment about your intent to work on the issue.
-After the issue is triaged, assign yourself to the issue.
+After the issue is triaged, assign the issue to yourself.
 Using the [guidelines on working on an issue](#Guidelines_for_working_on_an_issue), try to fix the problem by updating the appropriate source, such as:
 
 - The MDN Web Docs content (in English) in the [content](https://github.com/mdn/content) repository
@@ -150,7 +150,17 @@ The overall process for triaging includes some [general](#general_triaging_tasks
 
 These are the guidelines to follow while triaging each issue.
 
-#### Review the issue to determine the completeness of information
+#### Review if the issue is valid
+
+These are some of the things to keep in mind while reviewing the validity of an issue:
+
+- Check if the issue raised is valid and if the fix will improve the content for the readers and the website.
+- Evaluate if the impact of the fix will be small or site-wide.
+- Evaluate if the fix for the issue will need a discussion first, in which case, point the author to open a [discussion](https://github.com/mdn/mdn-community/discussions) instead.
+- Check if the issue is inline with our [writing guidelines](/en-US/docs/MDN/Writing_guidelines/Writing_style_guide) and [templates](/en-US/docs/MDN/Writing_guidelines/Page_structures/Page_types).
+- Check whether suggestions for adding links comply with our [external links policy](/en-US/docs/MDN/Writing_guidelines/Writing_style_guide#external_links).
+
+#### Review the issue for completeness of information
 
 Review each issue against the following checklist to ensure that the issue contains the described information for someone to start working on the bug:
 
@@ -159,7 +169,7 @@ Review each issue against the following checklist to ensure that the issue conta
 - URL of an example page or repository related to the bug, if appropriate.
 - A clear description of what the problem is.
 
-If any of the above information is not present, then you should ask the author of the issue to provide these details and resume triaging the issue only after those details have been provided.
+If any of the above information is not present, then you should ask the author of the issue to provide these details and resume triaging the issue only after those details have been provided. It is okay to wait for up to a week to get a response from the author.
 
 #### Set a priority label
 

--- a/issues.md
+++ b/issues.md
@@ -120,7 +120,7 @@ Using the [guidelines on working on an issue](#Guidelines_for_working_on_an_issu
 
 - The MDN Web Docs content (in English) in the [content](https://github.com/mdn/content) repository
 - The MDN Web Docs translated content in the [translated-content](https://github.com/mdn/translated-content) repository
-- The MDN Web Docs look and feel in the [yari](https://github.com/mdn/yari) repository
+- The MDN Web Docs website look and feel in the [yari](https://github.com/mdn/yari) repository
 
 Each repository includes useful information to guide you on how to contribute.
 
@@ -140,7 +140,7 @@ The overall process for triaging includes some [general](#general_triaging_tasks
 
 - You don't need to actively triage issues all the time. Set aside time, say 30 minutes every week, to triage issues on a regular basis in your area of responsibility. Triaging doesn't have to be done as part of a synchronous meeting or even at the same time as everyone else, but it should be done regularly to make sure that the backlog of untriaged bugs doesn't get too high.
 
-- Apart from triaging incoming issues every week, review the list of old bugs to see if there are any that are stalled, need closing, or are no longer relevant.
+- Apart from triaging incoming issues every week, review the list of old bugs to see if there are any that are stalled, need closing, or are no longer relevant. The `idle` label is automatically set on issues that have had no activity for 30 days.
   - Check assigned issues that are still open to see if the assignee is making progress. If there is no progress after a week of being assigned, ask them if they still have time to work on the issue. If another week passes by without any progress, unassign them and leave a comment indicating that you're making the issue available for other interested contributors.
   - If a pull request has been opened to fix the issue but has not been reviewed for a week, give the reviewer a gentle ping to ask if they can get to it.
   - If a pull request to fix the issue is waiting on review comments to be addressed after a week, then ask the author if they can respond to their review. If another week goes by, either fix the review comments yourself if you have time, or close the pull request and unassign the related issue.
@@ -163,10 +163,9 @@ These are some of the things to keep in mind while reviewing the validity of an 
 
 Review each issue against the following checklist to ensure that the issue contains the described information for someone to start working on the bug:
 
-- MDN URL where the problem has been found.
-- The specific heading or section on the MDN Web Docs page where the problem can be found.
-- URL of an example page or repository related to the bug, if appropriate.
-- A clear description of what the problem is.
+- URL of the MDN Web Docs page with the problem or URL of an example MDN Web Docs page if the problem exists on multiple pages.
+- The specific heading or section on the MDN Web Docs page where the problem was found.
+- A clear description of the incorrect, unhelpful, incomplete, or missing information.
 
 If any of the above information is not present, then you should ask the author of the issue to provide these details and resume triaging the issue only after those details have been provided. It is okay to wait for up to a week to get a response from the author.
 
@@ -180,7 +179,7 @@ For each bug, set a priority label based on the severity of the issue to help pe
 - Major issue: This type of issue could severely affect a page's usefulness. For example, a significant amount of out-of-date information, a complex and important code example that doesn't work, a significant amount of prose that is badly written and hard to understand, or a large number of broken links.
   - Labels: `p1` (will be addressed soon) and `p2` (will be addressed soon, but higher priority items will take precedence)
 
-- Minor issue — This is a type of improvement issue that can make the existing content better but does not affect learning or only has a minor effect on learning. Examples include typos, bad grammar, a broken link, a small amount of out-of-date information or badly-written prose, or a code snippet that doesn't work.
+- Minor issue — This is a type of improvement issue that can make the existing content better but does not affect learning or only has a minor effect on learning. Since these types of issues are not actively planned for, help from contributors to fix these issues is welcome and much appreciated. Fixing some of these issues can also provide the necessary practice to beginner contributors who are starting to get familiar with the contribution process. Examples include typos, bad grammar, a broken link, a small amount of out-of-date information or badly-written prose, or a code snippet that doesn't work.
   - Labels: `p3` (no visibility when the issue will be addressed)
 
 In general, critical issues should be fixed immediately and are most likely handled by MDN Web Docs staff and peers.

--- a/issues.md
+++ b/issues.md
@@ -32,11 +32,11 @@ Avoid doing the following:
 
 ## Guidelines for reporting an issue
 
-[Issues](https://docs.github.com/en/github/managing-your-work-on-github/about-issues) are used to track bugs. An issue must be a single actionable task or a collection of multiple, related actionable tasks and must have a clear actionable outcome.
+[Issues](https://docs.github.com/en/github/managing-your-work-on-github/about-issues) are used to track bugs. An issue must be a single actionable task or a collection of related actionable tasks and must have a clear outcome.
 
 ### Before filing an issue
 
-If you've found a bug with either the content on MDN Web Docs or the platform, search the current open issues in the [relevant repository](/en-US/docs/MDN/Community/Contributing/Our_repositories) to ensure that someone has not already reported the issue.
+If you think you've found a bug with the content on MDN Web Docs or with the look and feel of the website, search the current open issues in the [relevant repository](/en-US/docs/MDN/Community/Contributing/Our_repositories) and make sure that nobody else reported the issue.
 
 ### Reporting an issue
 
@@ -50,7 +50,7 @@ If you've found a bug with either the content on MDN Web Docs or the platform, s
 
   - **Issue description** must clearly describe the bug and the action required to resolve the issue. It must also list the task or sub-tasks to be completed to resolve the issue. Some other guidelines include:
     - Use the description field to indicate the status of the task or sub-tasks by using checklists.
-    - Updates to the status of a task should be conveyed by editing the task list in the issue description instead of adding a new comment. One should not have to scroll through comments or replies to find the status of a task or sub-task.
+    - Update the status of a task in the issue description instead of commenting on the issue. Use [task lists](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/about-task-lists) in the description if an issue has multiple parts. This helps others who may otherwise need to scroll through comments on the issue to determine the status of various tasks.
     - Comments in an issue should be limited to details or context that help resolve the issue.
 
 - If the information you provide in the issue is incomplete, then you might be contacted later during the [issue triaging process](#review_issue_to_determine_completeness_of_information).
@@ -63,9 +63,9 @@ If you've found a bug with either the content on MDN Web Docs or the platform, s
 
 - You can open an issue and [fix it yourself](#fixing_issues_yourself).
 
-### Creating an issue task tracker
+### Creating a task list issue
 
-If the issue you're opening is not to report a bug but to perform a series of tasks, you can create the issue as a tracker.
+If the issue you're opening is not to report a bug but to perform a series of tasks, you can create the issue as a [task list](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/about-task-lists).
 Explain the context or reason for performing the tasks in the description.
 Ensure that you list all the actionable tasks as a checklist.
 
@@ -113,15 +113,15 @@ These are the general steps for working on an issue:
 
 ### Fixing issues yourself
 
-If you spot a bug — whether it's a problem with site infrastructure or an error in documentation — you can try to fix it yourself.
+If you spot a bug — whether it's a problem with the website's look and feel or an error in documentation — you can try to fix it yourself. Learn how you can contribute by going through our [contribution guide](https://github.com/mdn/content/blob/main/CONTRIBUTING.md).
 
-[Report the problem](#guidelines_for_reporting_an_issue) as described earlier.
+In general, begin by [opening the issue](#guidelines_for_reporting_an_issue). Add a comment about your intent to work on the issue.
+After the issue is triaged, assign yourself to the issue.
+Using the [guidelines on working on an issue](#Guidelines_for_working_on_an_issue), try to fix the problem by updating the appropriate source, such as:
 
-You can fix the problem yourself by updating the appropriate source:
-
-- The MDN Web Docs content (in English) is found in the [content](https://github.com/mdn/content) repository.
-- The MDN Web Docs content translated in other locales is found in the [translated-content](https://github.com/mdn/translated-content) repository.
-- The MDN Web Docs platform code, which renders the content as MDN, is found in the [yari](https://github.com/mdn/yari) repository.
+- The MDN Web Docs content (in English) in the [content](https://github.com/mdn/content) repository
+- The MDN Web Docs translated content in the [translated-content](https://github.com/mdn/translated-content) repository
+- The MDN Web Docs look and feel in the [yari](https://github.com/mdn/yari) repository
 
 Each repository includes useful information to guide you on how to contribute.
 

--- a/issues.md
+++ b/issues.md
@@ -106,7 +106,7 @@ These are the general steps for working on an issue:
 
 4. **Make the changes:** Fork and branch the repository. Do your work and open a [pull request](/en-US/docs/MDN/Community/Pull_requests) in the repository. [Reference the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) in the pull request description. Depending on the files you've updated in the pull request, a reviewer will be assigned to your pull request automatically. (Teams per topic area are defined in the [CODEOWNERS](https://github.com/mdn/content/blob/main/.github/CODEOWNERS) file).
 
-   If you no longer have the time to work on the assigned issue, let the team know in a comment so that the issue can be assigned to someone else.
+   After opening the pull request, if you find you no longer have the time to make changes or incorporate review feedback, let the team know as soon as possible in a comment in the pull request. This will help the team assign another interested contributor to complete the work on the pull request and close the linked issue.
 
 5. After your pull request has been reviewed and merged, you can mark the linked issue as closed. If you opened the pull request with `Fixes #<issue>` verbiage, the issue will be closed automatically when the pull request is merged.
 

--- a/issues.md
+++ b/issues.md
@@ -4,7 +4,7 @@ As a contributor, you can report and work on an issue. Triaging is typically don
 
 ## General participation guidelines
 
-Always evaluate your contributions, while reporting an issue or participating in a conversation, to ensure that they are contributing to the overall progress and health of the project. Consider whether your issues and comments are on topic or if they are just adding noise.
+While reporting an issue or participating in a conversation, always ensure that your inputs are contributing to the overall progress of the project. Consider whether your issues and comments are on topic or if they are just adding noise.
 
 Dos:
 
@@ -20,72 +20,79 @@ Don'ts:
 
 ## Issue reporting guidelines
 
-An issue must be a single actionable task or a collection of multiple, related actionable tasks.
-The issue description must clearly state the bug and the action required to resolve the issue.
+[Issues](https://docs.github.com/en/github/managing-your-work-on-github/about-issues) are used to track bugs. An issue must be a single actionable task or a collection of multiple, related actionable tasks and must have a clear actionable outcome.
 
-Follow these guidelines while reporting an issue:
+### Before filing an issue
 
-- **Issue titles:** The title of an issue must convey succinctly the required action.
+If you've found a bug with either the content on MDN or the platform, search the current open issues in the [relevant repository](/en-US/docs/MDN/Community/Contributing/Our_repositories) to ensure someone has not already reported the issue.
 
-- **Description:** The description for an issue should list the task or tasks to be completed to resolve the issue. Use the description field to indicate the completion and outstanding status of the task or sub-tasks by using checklists. Updates to the status of a task should be done by editing the issue description or the task list instead of in a comment replying to an issue. One should not have to scroll through comments or replies to find the status of a task or sub-tasks.
+### While filing an issue
 
-### Discussions
+- To open an issue, use the appropriate template available in the repository.
 
-- Comments in an issue should be limited to details or context that helps resolve the issue.
-  If a discussion needs to take place to clarify an issue, or if a discussion begins, it should be moved to a GitHub discussion.
-- If an issue has no clear consensus on how to resolve it, it should be moved to a discussion.
-- If the requirements for completing the task expand while it's being resolved, or if the work is unclear, a discussion must be used to flesh out details for clarity.
+- Ensure that the issue description clearly states the bug and the action required to resolve the issue. Follow these guidelines while reporting a bug:
 
-[Issues](https://docs.github.com/en/github/managing-your-work-on-github/about-issues) are used to track all bugs and work that has a clear actionable outcome. If you have found a bug with either our content or the platform, please search current open issues against the [relevant repository](/en-US/docs/MDN/Community/Contributing/Our_repositories) to ensure someone has not already reported the issue. If the issue is new, please file an issue using the relevant template available in the repository.
+  - **Issue title:** Must convey succinctly the required action.
 
-> **Note:** If an issue has a triage label, we haven't reviewed it yet, and you shouldn't begin work on it.
+  - **Issue description:** Must list the task or sub-tasks to be completed to resolve the issue.
 
-If the issue you are filing is not to report a bug, please ensure that it lists actionable tasks or a clear outcome. For example:
+    - Use the description field to indicate the completion and outstanding status of the task or sub-tasks by using checklists. Updates to the status of a task should be done by editing the issue description or the task list instead of in a comment. One should not have to scroll through comments or replies to find the status of a task or sub-tasks.
+    - Comments in an issue should be limited to details or context that help resolve the issue. If you find yourself in one of the following situations, move the conversation to [MDN's GitHub discussions](https://github.com/mdn/mdn-community/discussions):
+      - A discussion needs to take place to clarify an issue
+      - A discussion begins after opening the issue
+      - The issue has no clear consensus on its resolution
+      - The requirements for completing the task expand while it's being resolved or the work is unclear
 
-```markdown
-## Remove \{{ warning }} macro from documents
+- If the issue you're filing is not to report a bug, you can create an issue tracker. Ensure that you list the actionable tasks or a clear outcome in the issue tracker. Also explain the context or reason for performing the tasks. For example:
 
-We should no longer be using the `\{{ warning }}` macro in our documentation.
+   ```markdown
+   ## Remove \{{ warning }} macro from documents
 
-### Task description
+   We should no longer be using the `\{{ warning }}` macro in our documentation because it has been deprecated.
 
-We should therefore replace all instances of the `\{{ warning }}` macro with the following:
+   ### Task description
 
-> **Warning:** Main subject line
->
-> Details of the warning.
-> It can have multiple paragraphs.
+   We should replace all instances of the `\{{ warning }}` macro with the following:
 
-### Actionable outcome
+   > **Warning:** Main subject line
+   >
+   > Details of the warning.
+   > It can have multiple paragraphs.
 
-- [ ] There are no more instances of the `\{{ warning }}` macro in the `mdn/content` repository.
-- [ ] Deprecate `\{{ warning }}` macro
-- [ ] Notify localization team leads of the change.
-```
+   ### Actionable outcome
+
+   - [ ] There are no more instances of the `\{{ warning }}` macro in the `mdn/content` repository.
+   - [ ] Deprecate `\{{ warning }}` macro
+   - [ ] Notify localization team leads of the change.
+   ```
 
 ## Working on an issue
 
-All repositories have an issue tracker, where you can find tasks to help contribute
+Remember that if you take on an issue, the expectation is for work to be completed in a timely manner. If you can no longer complete the required task, leave a comment and unassign yourself from the issue.
 
-Most repositories have a `help-wanted` label or `good-first-issue` label. Some do not, but this is not a pre-requisite and you are welcome to browse and pick something that is suitable for your skill set.
+These are the general steps for working on an issue:
 
-Once you've found an issue you'd like to work on, make sure no one else is assigned to the issue. Add a comment saying you would like to work on it and assign the issue to yourself.
+1. If you're looking to contribute, search for issues with `help wanted` or `good first issue` label. Most repositories have issues with these labels; some do not, but this is not a pre-requisite. You are welcome to browse and pick an issue that is suitable for your skill set.
 
-Most issues need some investigation before work can start, if you need to ask questions ask for help in the [MDN Web Docs chat room](https://chat.mozilla.org/#/room/#mdn:mozilla.org) on [Matrix](https://wiki.mozilla.org/Matrix).
+   > **Note:** An issue with the `needs triage` label indicates that the team has not reviewed the issue yet, and you shouldn't begin work on it.
 
-If you take on an issue we expect work to happen in a timely manner. If you can no longer take on the task, leave a comment and unassign yourself.
+2. After finding an issue you'd like to work on, make sure no one else is assigned to the issue. Add a comment saying you would like to work on it, and assign the issue to yourself.
 
-Fork and branch the repository, do your work and open a [pull request](/en-US/docs/MDN/Community/Pull_requests).
+   Most issues need some investigation before work can start. If you need to ask questions, ask for help in the [MDN Web Docs chat room](https://chat.mozilla.org/#/room/#mdn:mozilla.org) on [Matrix](https://wiki.mozilla.org/Matrix).
 
-Now and then, you may run into problems while using MDN. Whether it's a problem with site infrastructure or an error in documentation content, you can either try to fix it yourself or report the problem. While the former is preferred, the latter is sometimes the best you can manage, and that's okay too.
+3. Fork and branch the repository. Do your work and open a [pull request](/en-US/docs/MDN/Community/Pull_requests) in the repository.
+
+### Troubleshooting problems
+
+If you run into problems — whether it's a problem with site infrastructure or an error in documentation content — you can try to fix it yourself, report the problem (file an issue), or ask in Discord.
 
 The best thing you can possibly do is fix problems you spot yourself — this is done by updating the site source:
 
-- The MDN content itself (in English) is found in the [content](https://github.com/mdn/content) repo.
+- The MDN content itself (in English) is found in the [content](https://github.com/mdn/content) repository.
 - The MDN content, translated in other locales, is found in the [translated-content](https://github.com/mdn/translated-content) repo.
 - The MDN platform code, which renders the content as MDN, is found in the [yari](https://github.com/mdn/yari) repo.
 
-Each repo includes useful information to guide you on how to contribute.
+Each repository includes useful information to guide you on how to contribute.
 
 However, maybe you don't know the answer or are in the middle of a deadline on your own project, and need to jot down the problem so someone can look at it later.
 
@@ -189,7 +196,7 @@ For each bug, run through the following checklist to make sure the issue contain
 Does the issue contain:
 
 - The MDN URL where the problem has been found.
-- The URL of any example page or repo related to the bug, if appropriate.
+- The URL of any example page or repository related to the bug, if appropriate.
 - The specific heading on the MDN page where the problem can be found (if needed to find it).
 - A clear description of what the problem is.
 

--- a/issues.md
+++ b/issues.md
@@ -1,22 +1,33 @@
-# Issue reporting guidelines
+# Guidelines for reporting, triaging, and working on issues
 
-## General guidelines
+As a contributor, you can report and work on an issue. Triaging is typically done by people assigned the role of maintainers and owners.
 
-An issue must be an actionable task or an issue used to track multiple tasks.
-It must be clear at a glance what needs to be done for an issue to be resolved.
+## General participation guidelines
 
-**Issue titles:**
+Always evaluate your contributions, while reporting an issue or participating in a conversation, to ensure that they are contributing to the overall progress and health of the project. Consider whether your issues and comments are on topic or if they are just adding noise.
 
-- The title of an issue has to convey succinctly what the task is.
+Dos:
 
-**Description:**
-An issue's description should list what needs to be done and the status of the task or sub-tasks.
-It should be clear to a reader who has no context on the issue what the current status of the task is and what is left outstanding.
-The scope and status of an issue can be conveyed via a checklist or using labels.
+- Use [discussions](https://github.com/mdn/mdn-community/discussions) in the MDN project on GitHub before filing an issue. Use discussions to gain different viewpoints and to converge on an agreed upon course of action. This helps to keep issues focused and productive.
+- If you have a simple question, you can ask using other mechanisms like [chat rooms](https://chat.mozilla.org/#/room/#mdn:mozilla.org) or [forums](https://discourse.mozilla.org/c/mdn/236) without filing an issue.
+- Read our [contribution guidelines](/en-US/docs/MDN/Community) and [writing guidelines](/en-US/docs/MDN/Writing_guidelines) first to try to solve the issue yourself.
 
-- It should not be necessary to scroll through comments or replies to find the status of the task or sub-tasks.
-- The status of the task (or sub-tasks) must be visible in the issue description or via labels.
-- Updates to the status of the task should be done by editing the issue description or task list instead of in a comment replying to an issue.
+Don'ts:
+
+- Complicate issues by trying to discuss multiple topics or by making off-topic comments.
+- Open lots of issues asking vague questions.
+- Ask questions without trying to solve the problem yourself first.
+
+## Issue reporting guidelines
+
+An issue must be a single actionable task or a collection of multiple, related actionable tasks.
+The issue description must clearly state the bug and the action required to resolve the issue.
+
+Follow these guidelines while reporting an issue:
+
+- **Issue titles:** The title of an issue must convey succinctly the required action.
+
+- **Description:** The description for an issue should list the task or tasks to be completed to resolve the issue. Use the description field to indicate the completion and outstanding status of the task or sub-tasks by using checklists. Updates to the status of a task should be done by editing the issue description or the task list instead of in a comment replying to an issue. One should not have to scroll through comments or replies to find the status of a task or sub-tasks.
 
 ### Discussions
 
@@ -51,22 +62,6 @@ We should therefore replace all instances of the `\{{ warning }}` macro with the
 - [ ] Deprecate `\{{ warning }}` macro
 - [ ] Notify localization team leads of the change.
 ```
-
-## Make progress, not noise
-
-Think carefully about the way you handle communication in the project — make sure it is useful, and that it doesn't make other contributors jobs harder. Submitting pull requests to fix issues is great, but are they truly useful, and easy to review? Filing issues and joining in other conversations is fine, but are your issues and comments on topic, or are they just adding noise?
-
-As a rule, do:
-
-- Use [GitHub discussion](https://github.com/mdn/mdn-community/discussions) before filing an issue. This helps to keep issues focused and productive.
-- Ask questions using other mechanisms like [chat rooms](https://chat.mozilla.org/#/room/#mdn:mozilla.org) or [forums](https://discourse.mozilla.org/c/mdn/236) if you are not sure whether something is useful or have a simple question.
-- Read our [contribution guidelines](/en-US/docs/MDN/Community) and [writing guidelines](/en-US/docs/MDN/Writing_guidelines) first to try to solve the issue yourself.
-
-Don't:
-
-- Complicate issues by trying to discuss multiple topics at once, or making off-topic comments.
-- Open lots of issues asking vague questions.
-- Ask questions without trying to solve the problem yourself first.
 
 ## Working on an issue
 
@@ -251,4 +246,3 @@ At the end of your triage session, have a look through the older existing triage
 - Check assigned issues that are still open to see if the assignee is making progress. If they have done nothing after a week of being assigned, ask them if they still have to work on the issue. If another week passes and they have still done nothing, unassign them and say that you are opening this up again for others to take.
 - If a PR has been issued to fix the issue but it has not been reviewed for a week, give the reviewer a gentle ping to ask if they can get to it.
 - If a PR is waiting on review comments to be addressed after a week, then ask the submitter if they can respond to their review. If another week goes by, either fix the review comments yourself if you have time, or close the PR if not.
-

--- a/issues.md
+++ b/issues.md
@@ -96,16 +96,15 @@ These are the general steps for working on an issue:
 
    > **Note:** An issue with the `needs triage` label indicates that the MDN Web Docs core team has not reviewed the issue yet, and you shouldn't begin work on it.
 
-2. **Assign the issue to yourself:** After finding an issue you'd like to work on, make sure no one else is assigned to the issue. Add a comment saying you would like to work on it, and [assign the issue to yourself](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users#assigning-an-individual-issue-or-pull-request).
+2. **Assign the issue to yourself:** After finding an issue you'd like to work on, make sure that the issue is not assigned to anybody else. Add a comment saying you would like to work on the issue, and if you are able to, [assign the issue to yourself](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users#assigning-an-individual-issue-or-pull-request).
 
 3. **Do the research:** Most issues need some investigation before work can start.
 
    - Scope out the work that needs to be done. If you need to ask questions, ask for help in the [MDN Web Docs chat room](https://chat.mozilla.org/#/room/#mdn:mozilla.org) on [Matrix](https://wiki.mozilla.org/Matrix).
    - If the issue is well-described, and the work is pretty obvious, go ahead and do it.
    - If the issue is not well-described, and/or you are not sure what is needed, feel free to @mention the poster and ask for more information.
-   - If you are not still sure who to ask, ask for help in the [MDN Web Docs chat room](https://chat.mozilla.org/#/room/#mdn:mozilla.org) on [Matrix](https://wiki.mozilla.org/Matrix).
 
-4. **Make the changes:** Fork and branch the repository. Do your work and open a [pull request](/en-US/docs/MDN/Community/Pull_requests) in the repository. Comment in the issue and ask for a review of your pull request.
+4. **Make the changes:** Fork and branch the repository. Do your work and open a [pull request](/en-US/docs/MDN/Community/Pull_requests) in the repository. [Reference the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) in the pull request description. Depending on the files you've updated in the pull request, a reviewer will be assigned to your pull request automatically. (Teams per topic area are defined in the [CODEOWNERS](https://github.com/mdn/content/blob/main/.github/CODEOWNERS) file).
 
    If you no longer have the time to work on the assigned issue, let the team know in a comment so that the issue can be assigned to someone else.
 

--- a/issues.md
+++ b/issues.md
@@ -1,24 +1,34 @@
-# Reporting, triaging, and working on issues
+---
+title: Guidelines to open, triage, and work on issues
+slug: MDN/Community/Issues
+page-type: mdn-community-guide
+tags:
+  - meta
+  - community-guidelines
+  - governance
+---
 
-As a contributor, you can report and work on an issue.
+{{MDNSidebar}}
 
-Triaging is typically done by people assigned the role of maintainer and owner.
+As a contributor, you can [report](#Guidelines_for_reporting_an_issue) and [work](#guidelines_for_working_on_an_issue) on issues.
 
-## Guidelines for participation
+After you report an issue, the issue gets triaged. Issue [triaging](#guidelines_for_triaging_issues) is typically done by people assigned the role of a maintainer or an owner.
 
-While reporting an issue or participating in a conversation in an issue, always ensure that your inputs are contributing to the overall progress of the project. Consider whether the issues you open and your comments are on topic or if they are just adding noise.
+## General guidelines for participation
 
-Dos:
+While reporting an issue or participating in a conversation in an issue, always ensure that your inputs are contributing to the overall progress of the project. Consider whether the issues you open and your comments in an issue are constructive and on topic and are not just adding noise.
+
+Do the following:
 
 - Before filing an issue, consider if you need to start a [discussion](https://github.com/mdn/mdn-community/discussions) in the MDN project on GitHub. Use discussions to gain different viewpoints and to converge on an agreed upon course of action. This helps to keep issues focused and productive.
 - Before filing an issue, read our [contribution guide](https://github.com/mdn/content/blob/main/CONTRIBUTING.md) to try to fix the problem yourself.
 - If you have a question, you can ask using mechanisms like [chat rooms](https://chat.mozilla.org/#/room/#mdn:mozilla.org) or [forums](https://discourse.mozilla.org/c/mdn/236) without filing an issue.
 
-Don'ts:
+Avoid doing the following:
 
-- Complicate issues by trying to discuss multiple topics or by making off-topic comments.
-- Open lots of issues asking vague questions.
-- Ask questions without trying to solve the problem yourself first.
+- Complicating issues by trying to discuss multiple topics or by making off-topic comments.
+- Opening lots of issues asking vague questions.
+- Asking questions without trying to solve the problem yourself first.
 
 ## Guidelines for reporting an issue
 
@@ -28,9 +38,11 @@ Don'ts:
 
 If you've found a bug with either the content on MDN or the platform, search the current open issues in the [relevant repository](/en-US/docs/MDN/Community/Contributing/Our_repositories) to ensure that someone has not already reported the issue.
 
-### Reporting a bug
+### Reporting an issue
 
-- To open an issue, use the appropriate template available in the repository.
+- Depending on the problem you've discovered, report it by filing a [documentation issue](https://github.com/mdn/content/issues), a [localization issue](https://github.com/mdn/translated-content/issues), or a [platform issue](https://github.com/mdn/yari/issues).
+
+- To open an issue, use the appropriate template available in the repository. For example, to report a content bug, use the the [Content issue](<https://github.com/mdn/content/issues/new?assignees=&labels=needs+triage&template=content-bug.yml>) template in the `mdn/content` repository.
 
 - Provide sufficient information while reporting the issue:
 
@@ -39,15 +51,21 @@ If you've found a bug with either the content on MDN or the platform, search the
   - **Issue description** must clearly describe the bug and the action required to resolve the issue. It must also list the task or sub-tasks to be completed to resolve the issue. Some other guidelines include:
     - Use the description field to indicate the status of the task or sub-tasks by using checklists.
     - Updates to the status of a task should be conveyed by editing the task list in the issue description instead of adding a new comment. One should not have to scroll through comments or replies to find the status of a task or sub-task.
-    - Comments in an issue should be limited to details or context that help resolve the issue. If you find yourself in one of the following situations, move the conversation to [MDN's discussion on GitHub](https://github.com/mdn/mdn-community/discussions):
-      - A discussion needs to take place to clarify an issue.
-      - A discussion begins after opening the issue.
-      - The issue has no clear consensus on its resolution.
-      - The requirements for completing the task expand while it's being resolved or the work is unclear.
+    - Comments in an issue should be limited to details or context that help resolve the issue.
 
-### Creating a task tracker
+- If the information you provide in the issue is incomplete, then you might be contacted later during the [issue triaging process](#review_issue_to_determine_completeness_of_information).
 
-If the issue you're opening is not to report a bug but to perform a series of tasks, you can create an issue tracker.
+- If you find yourself in one of the following situations, move the conversation to [MDN's discussion on GitHub](https://github.com/mdn/mdn-community/discussions):
+  - A discussion needs to take place to clarify an issue.
+  - A discussion begins after opening the issue.
+  - The issue has no clear consensus on its resolution.
+  - The requirements for completing the task expand while it's being resolved or the work is unclear.
+
+- You can open an issue and [fix it yourself](#fixing_issues_yourself).
+
+### Creating an issue task tracker
+
+If the issue you're opening is not to report a bug but to perform a series of tasks, you can create the issue as a tracker.
 Explain the context or reason for performing the tasks in the description.
 Ensure that you list all the actionable tasks as a checklist.
 
@@ -65,91 +83,68 @@ For example:
 
    - [x] [accent-color](/en-US/docs/Web/CSS/accent-color) - checked, okay
    - [ ] [backdrop-filter](/en-US/docs/Web/CSS/backdrop-filter)
-   - [ ] [letter-spacing](/en-US/docs/Web/CSS/letter-spacing) - open pull request to move Accessibility concerns and Internationalization concerns before Specifications.
+   - [ ] [letter-spacing](/en-US/docs/Web/CSS/letter-spacing) - open pull request to move `Accessibility concerns` and `Internationalization concerns` sections before the `Specifications` section.
    ```
 
 ## Guidelines for working on an issue
 
-Remember that if you take on an issue, the expectation is for work to be completed in a timely manner. If you can no longer complete the required task, leave a comment and unassign yourself from the issue.
+Remember that if you take on an issue, the expectation is for the work to be completed in a timely manner. If you can no longer complete the required task, leave a comment and unassign yourself from the issue.
 
 These are the general steps for working on an issue:
 
-1. If you're looking to contribute, search for issues with `help wanted` or `good first issue` label. Most repositories have issues with these labels; some do not, but this is not a pre-requisite. You are welcome to browse and pick an issue that is suitable for your skill set.
+1. **Find an issue:** If you're looking to contribute, search for issues with `help wanted` or `good first issue` label. Most repositories have issues with these labels. You are welcome to browse and pick an issue that is suitable for your skill set.
 
-   > **Note:** An issue with the `needs triage` label indicates that the team has not reviewed the issue yet, and you shouldn't begin work on it.
+   > **Note:** An issue with the `needs triage` label indicates that the MDN core team has not reviewed the issue yet, and you shouldn't begin work on it.
 
-2. After finding an issue you'd like to work on, make sure no one else is assigned to the issue. Add a comment saying you would like to work on it, and assign the issue to yourself.
+2. **Assign yourself to the issue:** After finding an issue you'd like to work on, make sure no one else is assigned to the issue. Add a comment saying you would like to work on it, and assign the issue to yourself.
 
-3. Most issues need some investigation before work can start.
+3. **Do the research:** Most issues need some investigation before work can start.
 
    - Scope out the work that needs to be done. If you need to ask questions, ask for help in the [MDN Web Docs chat room](https://chat.mozilla.org/#/room/#mdn:mozilla.org) on [Matrix](https://wiki.mozilla.org/Matrix).
    - If the issue is well-described, and the work is pretty obvious, go ahead and do it.
    - If the issue is not well-described, and/or you are not sure what is needed, feel free to @mention the poster and ask for more information.
    - If you are not still sure who to ask, ask for help in the [MDN Web Docs chat room](https://chat.mozilla.org/#/room/#mdn:mozilla.org) on [Matrix](https://wiki.mozilla.org/Matrix).
 
-4. Fork and branch the repository. Do your work and open a [pull request](/en-US/docs/MDN/Community/Pull_requests) in the repository. Comment in the issue and ask for a review of your pull request.
+4. **Make the changes:** Fork and branch the repository. Do your work and open a [pull request](/en-US/docs/MDN/Community/Pull_requests) in the repository. Comment in the issue and ask for a review of your pull request.
 
    If you no longer have the time to work on the assigned issue, let the team know in a comment so that the issue can be assigned to someone else.
 
 5. After your pull request has been reviewed and merged, you can mark the linked issue as closed. If you opened the pull request with `Fixes #<issue>` verbiage, the issue will be closed automatically when the pull request is merged.
 
-## Choosing a GitHub issue to work on
+### Fixing issues yourself
 
-1. Write a comment in the issue saying that you would like to take it on, and we'll assign you to it.
+If you spot a bug — whether it's a problem with site infrastructure or an error in documentation — you can try to fix it yourself.
 
-   - If someone else is already assigned to the issue:
-
-     1. If this was more than one week ago, and there has not been much activity, @mention them and ask them if you can take it over, or otherwise help get it to completion.
-
-        - If they agree for you to take it, we'll assign you to it and remove them.
-        - If they agree for you to take it and some work has been done already, or the agreement is to help them out with it, we'll assign you to it alongside them.
-
-     2. If it was less than one week ago, then have some patience, and give them a chance to work on it.
-
-2. If the issue has been marked as complete but needing a review, and you want to review it, @mention them in the comments and say you'll review it.
-
-### Troubleshooting problems
-
-If you run into problems — whether it's a problem with site infrastructure or an error in documentation content — you can try to fix it yourself, report the problem (file an issue), or ask in Discord.
+[Report the problem](#guidelines_for_reporting_an_issue) as described earlier.
 
 You can fix the problem yourself by updating the appropriate source:
 
-- The MDN content itself (in English) is found in the [content](https://github.com/mdn/content) repository.
+- The MDN content (in English) is found in the [content](https://github.com/mdn/content) repository.
 - The MDN content translated in other locales is found in the [translated-content](https://github.com/mdn/translated-content) repository.
 - The MDN platform code, which renders the content as MDN, is found in the [yari](https://github.com/mdn/yari) repository.
 
 Each repository includes useful information to guide you on how to contribute.
 
-However, if you're unable to troubleshoot the problem or are in the middle of a deadline on your own project, note the problem providing sufficient information so that someone can look at it later.
+## Guidelines for triaging issues
 
-Depending on the problem you've discovered, report it by filing a [documentation issue](https://github.com/mdn/content/issues), a [localization issue](https://github.com/mdn/translated-content/issues), or a [platform issue](https://github.com/mdn/yari/issues).
+If you are a maintainer or an owner in the MDN GitHub organization, you are responsible for triaging issues in one or more MDN repository.
 
-## Reporting and working on bugs
+The overall process for triaging includes some [general](#general_triaging_tasks) and some [issue-specific tasks](#issue_specific_triaging_tasks).
 
-Anyone can report a content bug by writing an issue at <https://github.com/mdn/content/issues/new> using the "Content bug" issue template, or by using the "Report a problem with this content on GitHub" link at the bottom of each MDN page.
+### General triaging tasks
 
-Once reported, content bugs are listed at <https://github.com/mdn/content/issues>, and are designed to be done by individuals with minimal process requirements. Anyone is welcome to work on a content bug, using the process outlined at [Fixing MDN content bugs](/en-US/docs/MDN/Community/Issues).
+- When an issue is opened, the `needs triage` label is set on the issue automatically. You can search for this label to look for issues that [need to be triaged](#issue_specific_triaging_tasks). Contributors or anybody else should not work on the issue until the issue has been triaged. (Triagers should remember to remove the `needs triage` label after triaging the issue.)
 
-## Triaging process
+- In the [mdn/content repository](https://github.com/mdn/content/issues), an additional `Content:` label, such as `Content:CSS` or `Content:WebAPI`, is set on the issue automatically. This gets set based on the MDN URL mentioned in the issue. You can use the content-specific label to look for issues to be triaged in your specific topic area.
 
-At a high level, the process for triage looks like so:
+- If an issue concerns an active, non-en-US locale, set the appropriate label, such as `l10n-fr`, `l10n-zh`, or `l10n-ja`. The teams for those locales will pick these issues up and triage them.
 
-Triage preparation:
+- You don't need to actively triage issues all the time. Set aside time, say 30 minutes every week, to triage issues on a regular basis in your area of responsibility. Triaging doesn't have to be done as part of a synchronous meeting or even at the same time as everyone else, but it should be done regularly to make sure that the backlog of untriaged bugs doesn't get too high.
 
-- Decide on triagers — Who will do the regular triage?
-- Set initial labels — As soon as a new bug comes in, give it the "needs-triage" label, to signify that it needs to be triaged (this should happen automatically), plus a "Content:" label to signify what topic area it is in, e.g. "Content:HTML". Anyone can do this as they spot bugs coming in, but the MDN core team will keep an active eye on this.
-- Set aside triage time — set out a regular 30-minute slot in which to do the triage, each week.
-
-Triage for each issue:
-
-- Checklist — run through checklist to see if it is ready to triage.
-- Set priority measure — according to priority rules.
-- Provide further information to help other contributors start working on bugs more easily.
-- Set other labels — there are other labels to set, to help people to choose issues to work on.
-
-Check through old bugs — look at existing bugs, and see if there are any that are stalled, or need closing, etc.
-
-## Triage preparation
+- Apart from triaging incoming issues every week, review the list of old bugs to see if there are any that are stalled, need closing, or are no longer relevant.
+  - Check assigned issues that are still open to see if the assignee is making progress. If there is no progress after a week of being assigned, ask them if they still have time to work on the issue. If another week passes by without any progress, unassign them and leave a comment indicating that you're making the issue available for other interested contributors.
+  - If a pull request has been opened to fix the issue but has not been reviewed for a week, give the reviewer a gentle ping to ask if they can get to it.
+  - If a pull request to fix the issue is waiting on review comments to be addressed after a week, then ask the submitter if they can respond to their review. If another week goes by, either fix the review comments yourself if you have time, or close the pull request and unassign the related issue.
 
 ### Decide on triagers
 
@@ -170,60 +165,41 @@ We need an assigned triager to regularly triage bugs coming in on each MDN conte
 - WebAPI — Ruth John
 - WebExt — Caitlin/WebExt team
 
-### Set initial labels
+### Issue-specific triaging tasks
 
-As soon as a new issue is filed, the MDN core team, and anyone else who wishes to help, will add the following labels to that issue:
+These are the guidelines to follow while triaging each issue.
 
-- `needs-triage` — signals that this issue needs a proper triage, to get it ready to work on (this should happen automatically).
-- `Content:<area>` — specifies the content topic this issue relates to, e.g. `Content:HTML` or `Content:CSS`. This needed for the triagers to be able to find the issues in their specific areas.
-- `l10n-fr`, `l10n-zh`, `l10n-ja` — specifies that the issue filed concerns an active non-en-US locale. The teams for those locales will pick these issues up and triage them.
+#### Review the issue to determine the completeness of information
 
-### Set aside triage time
+Review each issue against the following checklist to ensure that the issue contains the described information for someone to start working on the bug:
 
-Triagers don't need to be actively triaging bugs all the time. Instead, they should set out a 30-minute slot in which to triage the bugs in their area of responsibility, each week.
-
-This doesn't have to be done as part of a synchronous meeting, or even at the same time as everyone else, but it should be done regularly, say once per week, to make sure that the backlog of untriaged bugs doesn't get too high.
-
-## Triage process for each issue
-
-### Checklist to determine if we have enough information
-
-For each bug, run through the following checklist to make sure the issue contains enough information for someone to start working on the bug.
-
-Does the issue contain:
-
-- The MDN URL where the problem has been found.
-- The URL of any example page or repository related to the bug, if appropriate.
-- The specific heading on the MDN page where the problem can be found (if needed to find it).
+- MDN URL where the problem has been found.
+- The specific heading or section on the MDN page where the problem can be found.
+- URL of an example page or repository related to the bug, if appropriate.
 - A clear description of what the problem is.
 
-If this information is not present, then the triager should ask the submitter of the issue to provide these details, and not continue triaging the issue until those details are provided.
+If any of the above information is not present, then you should ask the submitter of the issue to provide these details and resume triaging the issue only after those details have been provided.
 
-### Set priority measure
+#### Set a priority label
 
-For each bug, set a priority measure label to help people who want to work on the most important issues or areas (rather than the topics they are interested in).
+For each bug, set a priority label based on the severity of the issue to help people who want to work on the most important issues or areas.
 
-The levels of priority are:
+- Critical issue: This type of issue needs to be fixed as soon as possible, regardless of where it appears on the site. This type of issue could damage MDN's reputation severely and/or harm users. Examples of this issue include an incorrect code snippet, which if used in production, could create a severe security problem and undesirable content such as malware, profanity, pornography, hate speech, or links to such content.
+  - Label: `p0` (will be addressed immediately)
 
-- `P0` — A critical issue on any MDN doc.
-- `P1` — A major issue on a Tier 1 MDN doc.
-- `P2` — A minor issue on a Tier 1 MDN doc.
-- `P3` — A major issue on a Tier 2 MDN doc.
-- `P4` — A minor issue on a Tier 2 MDN doc.
+- Major issue: This type of issue could severely affect a page's usefulness. For example, a significant amount of out-of-date information, a complex and important code example that doesn't work, a significant amount of prose that is badly written and hard to understand, or a large number of broken links.
+  - Labels: `p1` (will be addressed soon) and `p2` (will be addressed soon, but higher priority items will take precedence)
 
-Definitions:
+- Minor issue — This is a type of improvement issue that can make the existing content better but does not affect learning or only has a minor effect on learning. Examples include typos, bad grammar, a broken link, a small amount of out-of-date information or badly-written prose, or a code snippet that doesn't work.
+  - Labels: `p3` (no visibility when the issue will be addressed)
 
-- Critical issue — Something that could damage MDN's reputation severely and/or harm users, which we need to fix as soon as possible, regardless of where it appears on the site. Examples include code examples that if used in production could create a severe security issue, undesirable content such as malware, profanity, pornography, hate speech, or other undesirable content, or links to such content.
-- Major issue — Something that could severely affect a page's usefulness, for example a significant amount of out-of-date information, a complex and important code example that doesn't work, a significant amount of prose that is badly written and hard to understand, a large number of broken links, etc.
-- Minor issue — something that doesn't look great but does not affect learning, or only has a minor effect on learning. Examples — Typos, bad grammar, a broken link, a small amount of out-of-date information or badly-written prose, a small code snippet that doesn't work.
+In general, critical issues should be fixed immediately and are most likely handled by MDN staff and peers.
 
-Generally speaking, critical issues should be fixed immediately, and would probably be handled by MDN staff/peers.
+#### Add helpful information
 
-### Provide further information
+If possible, add information that can help contributors to fix the issue. The information can be in the form of steps, direction, or reading resources. You can time-box this task to 5 minutes.
 
-It is really useful for other contributors to provide them with further information to help them fix issues; we'd like to recommend that triaging each bug involves a time-box of up to 5 minutes in which the triager quickly describes some steps to take to fix the bug, to help the person who eventually tries to fix it.
-
-For example:
+For example, as a triager, you can add the following information to the issue you are triaging:
 
 ```plain
 To whoever fixes this issue, it looks like the following is needed:
@@ -233,20 +209,14 @@ To whoever fixes this issue, it looks like the following is needed:
 * Update the compatibility data at Link-X
 ```
 
-### Set other labels
+#### Set other labels
 
-Next, set other labels as appropriate:
+Next, set the following labels as appropriate:
 
-- `10 minute task`, `30 minute task`, `1 hour task`, `multiple hour task` — Some people like to search for bugs based on how much time they've got to contribute, so we like to give a rough measure to allow people to choose. We appreciate that this is hard to estimate, and that different people will fix bugs at different speeds, but this is only supposed to be a rough measure. When setting it, think about how much time you think someone with a moderate-to-good amount of knowledge in the subject area would take to fix it.
-- `good first issue` — if the fix for the issue is really simple, and it would be a good practice issue for a newcomer just getting used to the system, mark it with this label.
-- `help wanted` — this seems to be a very popular label for people to use to search for things to do on open source projects, so we set this as a matter of course on successfully-triaged bugs.
-- `broken-link-internal`, `broken-link-external` — use these if the issue involves a link to a non-existent internal page, or a broken external link.
-- Once the triage process is completed, **don't forget to remove the `needs-triage label`.**
+- `effort: small`, `effort: medium`, `effort: large`: Some contributors like to search for bugs based on the time and effort that will be needed to fix the bug. So where possible, you should try to provide an estimate of the required effort.
+- `good first issue`: Set this label on the issue if the fix for the issue is really simple and if fixing the issue would provide good practice for a newcomer who is getting used to the process.
+- `help wanted`: Set this label if the issue requires help from someone who knows about or is familiar with the topic. This is a popular label and some contributors use it to search for issues to work on in open source projects in their areas of familiarity or expertise.
+- `broken link internal`, `broken link external` — Set the appropriate label if the issue involves a link to a non-existent internal page or a broken external link.
+- `needs content update`: Set this label if the issue fix in another repository will need an equivalent fix in the `mdn/content` repository.
 
-## Check through old issues
-
-At the end of your triage session, have a look through the older existing triaged issues in your topic area, and check to make sure none of the issues are being unnecessarily stalled or clogged up:
-
-- Check assigned issues that are still open to see if the assignee is making progress. If they have done nothing after a week of being assigned, ask them if they still have to work on the issue. If another week passes and they have still done nothing, unassign them and say that you are opening this up again for others to take.
-- If a PR has been issued to fix the issue but it has not been reviewed for a week, give the reviewer a gentle ping to ask if they can get to it.
-- If a PR is waiting on review comments to be addressed after a week, then ask the submitter if they can respond to their review. If another week goes by, either fix the review comments yourself if you have time, or close the PR if not.
+   > **Note:** After the triage process is complete, remove the `needs triage` label.

--- a/issues.md
+++ b/issues.md
@@ -92,7 +92,7 @@ Remember that if you take on an issue, the expectation is for the work to be com
 
 These are the general steps for working on an issue:
 
-1. **Find an issue:** If you're looking to contribute, search for issues with `help wanted` or `good first issue` label. Most repositories have issues with these labels. You are welcome to browse and pick an issue that is suitable for your skill set. Another useful place to look for issues to work on is the [MDN Contributors Task Board](https://github.com/orgs/mdn/projects/25). This project view lists open issues from multiple repositories. You can filter the list based on the topics (`Labels` column) you're interested in. See the description of some of the [labels](#Set_other_labels) that get applied during the issue triage process.
+1. **Find an issue:** If you're looking to contribute, search for issues with [`good first issue`, `help wanted`](#Set_other_labels) or [`p3`](#Set_a_priority_label) label. Most repositories have issues with these labels. You are welcome to browse and pick an issue that is suitable for your skill set. Another useful place to look for issues to work on is the [MDN Contributors Task Board](https://github.com/orgs/mdn/projects/25). This project view lists open issues from multiple repositories. You can filter the list based on the topics (`Labels` column) you're interested in. See the description of some of the [labels](#Set_other_labels) that get applied during the issue triage process.
 
    > **Note:** An issue with the `needs triage` label indicates that the MDN Web Docs core team has not reviewed the issue yet, and you shouldn't begin work on it.
 
@@ -186,7 +186,7 @@ In general, critical issues should be fixed immediately and are most likely hand
 
 #### Add helpful information
 
-If possible, add information that can help contributors to fix the issue. The information can be in the form of steps, direction, or reading resources. You can time-box this task to 5 minutes.
+If possible, add information that can help contributors to fix the issue. The information can be in the form of steps, general approach, links to other similar fixed issues, or reading resources. A well-laid out plan or steps is especially required in issues that are labeled `good first issue` and can help ramp up new contributors quickly. You can time-box this task to 5-10 minutes.
 
 For example, as a triager, you can add the following information to the issue you are triaging:
 

--- a/issues.md
+++ b/issues.md
@@ -78,25 +78,34 @@ These are the general steps for working on an issue:
 
 2. After finding an issue you'd like to work on, make sure no one else is assigned to the issue. Add a comment saying you would like to work on it, and assign the issue to yourself.
 
-   Most issues need some investigation before work can start. If you need to ask questions, ask for help in the [MDN Web Docs chat room](https://chat.mozilla.org/#/room/#mdn:mozilla.org) on [Matrix](https://wiki.mozilla.org/Matrix).
+3. Most issues need some investigation before work can start.
 
-3. Fork and branch the repository. Do your work and open a [pull request](/en-US/docs/MDN/Community/Pull_requests) in the repository.
+   - Scope out the work that needs to be done. If you need to ask questions, ask for help in the [MDN Web Docs chat room](https://chat.mozilla.org/#/room/#mdn:mozilla.org) on [Matrix](https://wiki.mozilla.org/Matrix).
+   - If the issue is well-described, and the work is pretty obvious, go ahead and do it.
+   - If the issue is not well-described, and/or you are not sure what is needed, feel free to @mention the poster and ask for more information.
+   - If you are not still sure who to ask, ask for help in the [MDN Web Docs chat room](https://chat.mozilla.org/#/room/#mdn:mozilla.org) on [Matrix](https://wiki.mozilla.org/Matrix).
+
+4. Fork and branch the repository. Do your work and open a [pull request](/en-US/docs/MDN/Community/Pull_requests) in the repository. Comment in the issue and ask for a review of your pull request.
+
+   If you no longer have the time to work on the assigned issue, let the team know in a comment so that the issue can be assigned to someone else.
+
+5. After your pull request has been reviewed and merged, you can mark the linked issue as closed. If you opened the pull request with `Fixes #<issue>` verbiage, the issue will be closed automatically when the pull request is merged.
 
 ### Troubleshooting problems
 
 If you run into problems — whether it's a problem with site infrastructure or an error in documentation content — you can try to fix it yourself, report the problem (file an issue), or ask in Discord.
 
-The best thing you can possibly do is fix problems you spot yourself — this is done by updating the site source:
+You can fix the problem yourself by updating the appropriate source:
 
 - The MDN content itself (in English) is found in the [content](https://github.com/mdn/content) repository.
-- The MDN content, translated in other locales, is found in the [translated-content](https://github.com/mdn/translated-content) repo.
-- The MDN platform code, which renders the content as MDN, is found in the [yari](https://github.com/mdn/yari) repo.
+- The MDN content translated in other locales is found in the [translated-content](https://github.com/mdn/translated-content) repository.
+- The MDN platform code, which renders the content as MDN, is found in the [yari](https://github.com/mdn/yari) repository.
 
 Each repository includes useful information to guide you on how to contribute.
 
-However, maybe you don't know the answer or are in the middle of a deadline on your own project, and need to jot down the problem so someone can look at it later.
+However, if you're unable to troubleshoot the problem or are in the middle of a deadline on your own project, note the problem providing sufficient information so that someone can look at it later.
 
-The way to report a documentation problem by filing an [documentation issue](https://github.com/mdn/content/issues), [localization issue](https://github.com/mdn/translated-content/issues) or [platform issue](https://github.com/mdn/yari/issues), depending on what the problem you've discovered relates to.
+Depending on the problem you've discovered, report it by filing a [documentation issue](https://github.com/mdn/content/issues), a [localization issue](https://github.com/mdn/translated-content/issues), or a [platform issue](https://github.com/mdn/yari/issues).
 
 ## When choosing a GitHub issue to work on
 
@@ -112,20 +121,6 @@ The way to report a documentation problem by filing an [documentation issue](htt
      2. If it was less than one week ago, then have some patience, and give them a chance to work on it.
 
 2. If the issue has been marked as complete but needing a review, and you want to review it, @mention them in the comments and say you'll review it.
-
-## When you've been assigned to an issue
-
-1. Scope out the remainder of the work that needs to be done.
-
-   - If the issue is well-described, and the work is pretty obvious, go ahead and do it.
-   - If the issue is not well-described, and/or you are not sure what is needed, feel free to @mention the poster and ask for more information.
-   - If you are not still sure who to ask, ask for help in the [MDN Web Docs chat room](https://chat.mozilla.org/#/room/#mdn:mozilla.org) on [Matrix](https://wiki.mozilla.org/Matrix).
-
-2. Once you think you've fixed an issue, ask for a review in the comments.
-3. Once an issue has been successfully reviewed and comments answered, you can mark it as closed.
-4. If you no longer have time to work on an issue, let us know in a comment so we can assign it someone else.
-
-This document looks at the process for triaging content bugs and getting them ready for contributors to effectively work on.
 
 ## Reporting and working on bugs
 

--- a/issues.md
+++ b/issues.md
@@ -36,7 +36,7 @@ Avoid doing the following:
 
 ### Before filing an issue
 
-If you think you've found a bug with the content on MDN Web Docs or with the look and feel of the website, search the current open issues in the [relevant repository](/en-US/docs/MDN/Community/Contributing/Our_repositories) and make sure that nobody else reported the issue.
+If you think you've found a bug with the content on MDN Web Docs or with the look and feel of the website, search the current open issues in the [relevant repository](/en-US/docs/MDN/Community/Contributing/Our_repositories) and make sure nobody else has reported the issue.
 
 ### Reporting an issue
 

--- a/issues.md
+++ b/issues.md
@@ -88,7 +88,7 @@ For example:
 
 ## Guidelines for working on an issue
 
-Remember that if you take on an issue, the expectation is for the work to be completed in a timely manner. If you can no longer complete the required task, leave a comment and unassign yourself from the issue.
+Remember that if you take on an issue, the expectation is for the work to be completed in a timely manner. If you're not able to make any progress for a week after being assigned or can no longer complete the required task, leave a comment and unassign yourself from the issue.
 
 These are the general steps for working on an issue:
 
@@ -145,25 +145,6 @@ The overall process for triaging includes some [general](#general_triaging_tasks
   - Check assigned issues that are still open to see if the assignee is making progress. If there is no progress after a week of being assigned, ask them if they still have time to work on the issue. If another week passes by without any progress, unassign them and leave a comment indicating that you're making the issue available for other interested contributors.
   - If a pull request has been opened to fix the issue but has not been reviewed for a week, give the reviewer a gentle ping to ask if they can get to it.
   - If a pull request to fix the issue is waiting on review comments to be addressed after a week, then ask the submitter if they can respond to their review. If another week goes by, either fix the review comments yourself if you have time, or close the pull request and unassign the related issue.
-
-### Decide on triagers
-
-We need an assigned triager to regularly triage bugs coming in on each MDN content area. We currently have the following triagers assigned:
-
-- Accessibility — Eric Bailey?
-- CSS — Rachel Andrew
-- DevTools — Hamish Willee
-- HTML — Rachel Andrew
-- HTTP — Florian Scholz
-- JS — Florian Scholz
-- Learn — Chris Mills
-- Learn:CSS — Rachel Andrew
-- Learn:Express / Learn:Django — Hamish Willee
-- Media — Ruth John
-- Other — Ruth John
-- SVG — André Jaenisch
-- WebAPI — Ruth John
-- WebExt — Caitlin/WebExt team
 
 ### Issue-specific triaging tasks
 

--- a/issues.md
+++ b/issues.md
@@ -1,16 +1,18 @@
-# Guidelines for reporting, triaging, and working on issues
+# Reporting, triaging, and working on issues
 
-As a contributor, you can report and work on an issue. Triaging is typically done by people assigned the role of maintainers and owners.
+As a contributor, you can report and work on an issue.
 
-## General participation guidelines
+Triaging is typically done by people assigned the role of maintainer and owner.
 
-While reporting an issue or participating in a conversation, always ensure that your inputs are contributing to the overall progress of the project. Consider whether your issues and comments are on topic or if they are just adding noise.
+## Guidelines for participation
+
+While reporting an issue or participating in a conversation in an issue, always ensure that your inputs are contributing to the overall progress of the project. Consider whether the issues you open and your comments are on topic or if they are just adding noise.
 
 Dos:
 
-- Use [discussions](https://github.com/mdn/mdn-community/discussions) in the MDN project on GitHub before filing an issue. Use discussions to gain different viewpoints and to converge on an agreed upon course of action. This helps to keep issues focused and productive.
-- If you have a simple question, you can ask using other mechanisms like [chat rooms](https://chat.mozilla.org/#/room/#mdn:mozilla.org) or [forums](https://discourse.mozilla.org/c/mdn/236) without filing an issue.
-- Read our [contribution guidelines](/en-US/docs/MDN/Community) and [writing guidelines](/en-US/docs/MDN/Writing_guidelines) first to try to solve the issue yourself.
+- Before filing an issue, consider if you need to start a [discussion](https://github.com/mdn/mdn-community/discussions) in the MDN project on GitHub. Use discussions to gain different viewpoints and to converge on an agreed upon course of action. This helps to keep issues focused and productive.
+- Before filing an issue, read our [contribution guide](https://github.com/mdn/content/blob/main/CONTRIBUTING.md) to try to fix the problem yourself.
+- If you have a question, you can ask using mechanisms like [chat rooms](https://chat.mozilla.org/#/room/#mdn:mozilla.org) or [forums](https://discourse.mozilla.org/c/mdn/236) without filing an issue.
 
 Don'ts:
 
@@ -18,55 +20,55 @@ Don'ts:
 - Open lots of issues asking vague questions.
 - Ask questions without trying to solve the problem yourself first.
 
-## Issue reporting guidelines
+## Guidelines for reporting an issue
 
 [Issues](https://docs.github.com/en/github/managing-your-work-on-github/about-issues) are used to track bugs. An issue must be a single actionable task or a collection of multiple, related actionable tasks and must have a clear actionable outcome.
 
 ### Before filing an issue
 
-If you've found a bug with either the content on MDN or the platform, search the current open issues in the [relevant repository](/en-US/docs/MDN/Community/Contributing/Our_repositories) to ensure someone has not already reported the issue.
+If you've found a bug with either the content on MDN or the platform, search the current open issues in the [relevant repository](/en-US/docs/MDN/Community/Contributing/Our_repositories) to ensure that someone has not already reported the issue.
 
-### While filing an issue
+### Reporting a bug
 
 - To open an issue, use the appropriate template available in the repository.
 
-- Ensure that the issue description clearly states the bug and the action required to resolve the issue. Follow these guidelines while reporting a bug:
+- Provide sufficient information while reporting the issue:
 
-  - **Issue title:** Must convey succinctly the required action.
+  - **Issue title** must convey succinctly the _required action_.
 
-  - **Issue description:** Must list the task or sub-tasks to be completed to resolve the issue.
+  - **Issue description** must clearly describe the bug and the action required to resolve the issue. It must also list the task or sub-tasks to be completed to resolve the issue. Some other guidelines include:
+    - Use the description field to indicate the status of the task or sub-tasks by using checklists.
+    - Updates to the status of a task should be conveyed by editing the task list in the issue description instead of adding a new comment. One should not have to scroll through comments or replies to find the status of a task or sub-task.
+    - Comments in an issue should be limited to details or context that help resolve the issue. If you find yourself in one of the following situations, move the conversation to [MDN's discussion on GitHub](https://github.com/mdn/mdn-community/discussions):
+      - A discussion needs to take place to clarify an issue.
+      - A discussion begins after opening the issue.
+      - The issue has no clear consensus on its resolution.
+      - The requirements for completing the task expand while it's being resolved or the work is unclear.
 
-    - Use the description field to indicate the completion and outstanding status of the task or sub-tasks by using checklists. Updates to the status of a task should be done by editing the issue description or the task list instead of in a comment. One should not have to scroll through comments or replies to find the status of a task or sub-tasks.
-    - Comments in an issue should be limited to details or context that help resolve the issue. If you find yourself in one of the following situations, move the conversation to [MDN's GitHub discussions](https://github.com/mdn/mdn-community/discussions):
-      - A discussion needs to take place to clarify an issue
-      - A discussion begins after opening the issue
-      - The issue has no clear consensus on its resolution
-      - The requirements for completing the task expand while it's being resolved or the work is unclear
+### Creating a task tracker
 
-- If the issue you're filing is not to report a bug, you can create an issue tracker. Ensure that you list the actionable tasks or a clear outcome in the issue tracker. Also explain the context or reason for performing the tasks. For example:
+If the issue you're opening is not to report a bug but to perform a series of tasks, you can create an issue tracker.
+Explain the context or reason for performing the tasks in the description.
+Ensure that you list all the actionable tasks as a checklist.
+
+For example:
 
    ```markdown
-   ## Remove \{{ warning }} macro from documents
+   // Issue title
+   Ensure sections follow the order defined in the CSS property template
 
-   We should no longer be using the `\{{ warning }}` macro in our documentation because it has been deprecated.
+   // Issue description
+   The CSS property page template is defined [here](/en-US/docs/MDN/Writing_guidelines/Page_structures/Page_types/CSS_property_page_template).
+   This issue tracker will be used to compare the documented CSS properties with the template and track changes to the property pages for compliance.
 
-   ### Task description
+   ### List of pages checked
 
-   We should replace all instances of the `\{{ warning }}` macro with the following:
-
-   > **Warning:** Main subject line
-   >
-   > Details of the warning.
-   > It can have multiple paragraphs.
-
-   ### Actionable outcome
-
-   - [ ] There are no more instances of the `\{{ warning }}` macro in the `mdn/content` repository.
-   - [ ] Deprecate `\{{ warning }}` macro
-   - [ ] Notify localization team leads of the change.
+   - [x] [accent-color](/en-US/docs/Web/CSS/accent-color) - checked, okay
+   - [ ] [backdrop-filter](/en-US/docs/Web/CSS/backdrop-filter)
+   - [ ] [letter-spacing](/en-US/docs/Web/CSS/letter-spacing) - open pull request to move Accessibility concerns and Internationalization concerns before Specifications.
    ```
 
-## Working on an issue
+## Guidelines for working on an issue
 
 Remember that if you take on an issue, the expectation is for work to be completed in a timely manner. If you can no longer complete the required task, leave a comment and unassign yourself from the issue.
 
@@ -91,6 +93,21 @@ These are the general steps for working on an issue:
 
 5. After your pull request has been reviewed and merged, you can mark the linked issue as closed. If you opened the pull request with `Fixes #<issue>` verbiage, the issue will be closed automatically when the pull request is merged.
 
+## Choosing a GitHub issue to work on
+
+1. Write a comment in the issue saying that you would like to take it on, and we'll assign you to it.
+
+   - If someone else is already assigned to the issue:
+
+     1. If this was more than one week ago, and there has not been much activity, @mention them and ask them if you can take it over, or otherwise help get it to completion.
+
+        - If they agree for you to take it, we'll assign you to it and remove them.
+        - If they agree for you to take it and some work has been done already, or the agreement is to help them out with it, we'll assign you to it alongside them.
+
+     2. If it was less than one week ago, then have some patience, and give them a chance to work on it.
+
+2. If the issue has been marked as complete but needing a review, and you want to review it, @mention them in the comments and say you'll review it.
+
 ### Troubleshooting problems
 
 If you run into problems — whether it's a problem with site infrastructure or an error in documentation content — you can try to fix it yourself, report the problem (file an issue), or ask in Discord.
@@ -107,28 +124,13 @@ However, if you're unable to troubleshoot the problem or are in the middle of a 
 
 Depending on the problem you've discovered, report it by filing a [documentation issue](https://github.com/mdn/content/issues), a [localization issue](https://github.com/mdn/translated-content/issues), or a [platform issue](https://github.com/mdn/yari/issues).
 
-## When choosing a GitHub issue to work on
-
-1. Write a comment in the issue saying that you would like to take it on, and we'll assign you to it.
-
-   - If someone else is already assigned to the issue:
-
-     1. If this was more than one week ago, and there has not been much activity, @mention them and ask them if you can take it over, or otherwise help get it to completion.
-
-        - If they agree for you to take it, we'll assign you to it and remove them.
-        - If they agree for you to take it and some work has been done already, or the agreement is to help them out with it, we'll assign you to it alongside them.
-
-     2. If it was less than one week ago, then have some patience, and give them a chance to work on it.
-
-2. If the issue has been marked as complete but needing a review, and you want to review it, @mention them in the comments and say you'll review it.
-
 ## Reporting and working on bugs
 
 Anyone can report a content bug by writing an issue at <https://github.com/mdn/content/issues/new> using the "Content bug" issue template, or by using the "Report a problem with this content on GitHub" link at the bottom of each MDN page.
 
 Once reported, content bugs are listed at <https://github.com/mdn/content/issues>, and are designed to be done by individuals with minimal process requirements. Anyone is welcome to work on a content bug, using the process outlined at [Fixing MDN content bugs](/en-US/docs/MDN/Community/Issues).
 
-## Overall triage process
+## Triaging process
 
 At a high level, the process for triage looks like so:
 

--- a/issues.md
+++ b/issues.md
@@ -20,7 +20,7 @@ While reporting an issue or participating in a conversation in an issue, always 
 
 Do the following:
 
-- Before filing an issue, consider if you need to start a [discussion](https://github.com/mdn/mdn-community/discussions) in the MDN project on GitHub. Use discussions to gain different viewpoints and to converge on an agreed upon course of action. This helps to keep issues focused and productive.
+- Before filing an issue, consider if you need to start a [discussion](https://github.com/mdn/mdn-community/discussions) in the MDN Web Docs project on GitHub. Use discussions to gain different viewpoints and to converge on an agreed upon course of action. This helps to keep issues focused and productive.
 - Before filing an issue, read our [contribution guide](https://github.com/mdn/content/blob/main/CONTRIBUTING.md) to try to fix the problem yourself.
 - If you have a question, you can ask using mechanisms like [chat rooms](https://chat.mozilla.org/#/room/#mdn:mozilla.org) or [forums](https://discourse.mozilla.org/c/mdn/236) without filing an issue.
 
@@ -36,7 +36,7 @@ Avoid doing the following:
 
 ### Before filing an issue
 
-If you've found a bug with either the content on MDN or the platform, search the current open issues in the [relevant repository](/en-US/docs/MDN/Community/Contributing/Our_repositories) to ensure that someone has not already reported the issue.
+If you've found a bug with either the content on MDN Web Docs or the platform, search the current open issues in the [relevant repository](/en-US/docs/MDN/Community/Contributing/Our_repositories) to ensure that someone has not already reported the issue.
 
 ### Reporting an issue
 
@@ -94,7 +94,7 @@ These are the general steps for working on an issue:
 
 1. **Find an issue:** If you're looking to contribute, search for issues with `help wanted` or `good first issue` label. Most repositories have issues with these labels. You are welcome to browse and pick an issue that is suitable for your skill set.
 
-   > **Note:** An issue with the `needs triage` label indicates that the MDN core team has not reviewed the issue yet, and you shouldn't begin work on it.
+   > **Note:** An issue with the `needs triage` label indicates that the MDN Web Docs core team has not reviewed the issue yet, and you shouldn't begin work on it.
 
 2. **Assign yourself to the issue:** After finding an issue you'd like to work on, make sure no one else is assigned to the issue. Add a comment saying you would like to work on it, and assign the issue to yourself.
 
@@ -119,15 +119,15 @@ If you spot a bug — whether it's a problem with site infrastructure or an erro
 
 You can fix the problem yourself by updating the appropriate source:
 
-- The MDN content (in English) is found in the [content](https://github.com/mdn/content) repository.
-- The MDN content translated in other locales is found in the [translated-content](https://github.com/mdn/translated-content) repository.
-- The MDN platform code, which renders the content as MDN, is found in the [yari](https://github.com/mdn/yari) repository.
+- The MDN Web Docs content (in English) is found in the [content](https://github.com/mdn/content) repository.
+- The MDN Web Docs content translated in other locales is found in the [translated-content](https://github.com/mdn/translated-content) repository.
+- The MDN Web Docs platform code, which renders the content as MDN, is found in the [yari](https://github.com/mdn/yari) repository.
 
 Each repository includes useful information to guide you on how to contribute.
 
 ## Guidelines for triaging issues
 
-If you are a maintainer or an owner in the MDN GitHub organization, you are responsible for triaging issues in one or more MDN repository.
+If you are a maintainer or an owner in the MDN Web Docs GitHub organization, you are responsible for triaging issues in one or more MDN Web Docs repository.
 
 The overall process for triaging includes some [general](#general_triaging_tasks) and some [issue-specific tasks](#issue_specific_triaging_tasks).
 
@@ -155,7 +155,7 @@ These are the guidelines to follow while triaging each issue.
 Review each issue against the following checklist to ensure that the issue contains the described information for someone to start working on the bug:
 
 - MDN URL where the problem has been found.
-- The specific heading or section on the MDN page where the problem can be found.
+- The specific heading or section on the MDN Web Docs page where the problem can be found.
 - URL of an example page or repository related to the bug, if appropriate.
 - A clear description of what the problem is.
 
@@ -174,7 +174,7 @@ For each bug, set a priority label based on the severity of the issue to help pe
 - Minor issue — This is a type of improvement issue that can make the existing content better but does not affect learning or only has a minor effect on learning. Examples include typos, bad grammar, a broken link, a small amount of out-of-date information or badly-written prose, or a code snippet that doesn't work.
   - Labels: `p3` (no visibility when the issue will be addressed)
 
-In general, critical issues should be fixed immediately and are most likely handled by MDN staff and peers.
+In general, critical issues should be fixed immediately and are most likely handled by MDN Web Docs staff and peers.
 
 #### Add helpful information
 


### PR DESCRIPTION
This PR covers the rewrite and restructuring of the following two pages:
https://developer.mozilla.org/en-US/docs/MDN/Community/Issues
https://developer.mozilla.org/en-US/docs/MDN/Community/Issues/Issue_triage

----

The content is now structured as:
```
# Guidelines to open, triage, and work on issues
  ## General guidelines for participation
  ## Guidelines for reporting an issue
    ### Before filing an issue
    ### Reporting an issue
    ### Creating an issue task tracker
  ## Guidelines for working on an issue
    ### Fixing issues yourself
  ## Guidelines for triaging issues
    ### General triaging tasks
    ### Issue-specific triaging tasks
      #### Review the issue to determine the completeness of information
      #### Set a priority label
      #### Add helpful information
      #### Set other labels
```

- There is some intentional overlap between 'General guidelines' and 'Before filing an issue'.
- The example with the "warning" macro has been replaced with a new example in the "Creating an issue task tracker" section.
- The [updated label definitions](https://github.com/mdn/mdn/issues/285) have been used in the triaging sections.

----

Reviewed and updated the status of tasks in https://github.com/mdn/mdn/issues/179

----

TO DOs:

- [ ] Add links to maintainer and owner roles
- [ ] Add link to discord invite (?) ([comment](https://github.com/mdn/temp-processes/pull/7#discussion_r1062394324))
- [ ] Move the section "Guidelines for triaging issues" between "Guidelines for reporting an issue" and "Guidelines for working on an issue".
- [ ] Add link in content issue template to the guidelines here for "Reporting an issue" ([comment](https://github.com/mdn/temp-processes/pull/7#discussion_r1062389703))